### PR TITLE
Add debug logs for shop discovery and interactions

### DIFF
--- a/src/ServerScriptService/Scripts/TeleportHandler.server.lua
+++ b/src/ServerScriptService/Scripts/TeleportHandler.server.lua
@@ -4,8 +4,12 @@ local Remotes = RS:WaitForChild("Remotes")
 local plotsFolder = workspace:WaitForChild("Plots")
 
 -- carpeta de tiendas puede estar en 'Hub/Shops' o directamente en 'Shops'
-local shopsParent = workspace:FindFirstChild("Hub") or workspace
-local shops = shopsParent:WaitForChild("Shops")
+local shops = workspace:FindFirstChild("Shops", true)
+if not shops then
+       warn("[TeleportHandler] No encontré carpeta 'Shops' en Workspace")
+       return
+end
+print("[TeleportHandler] shops", shops:GetFullName())
 
 local toPlot = Remotes:WaitForChild("TeleportToPlot")
 local toShop = Remotes:WaitForChild("TeleportToShop")
@@ -51,8 +55,12 @@ end)
 
 toShop.OnServerEvent:Connect(function(plr, shopName)
        shopName = tostring(shopName or "")
-       local shop = shops:FindFirstChild(shopName)
-       if not shop then return end
+       local shop = shops:FindFirstChild(shopName, true)
+       if not shop then
+               warn("[TeleportHandler] No encontré tienda", shopName)
+               return
+       end
+       print("[TeleportHandler] TeleportToShop", plr.Name, "->", shop:GetFullName())
        local char = plr.Character or plr.CharacterAdded:Wait()
        pivotCharacter(char, shop.CFrame)
 end)


### PR DESCRIPTION
## Summary
- Log GUI references and shop locations to trace upgrade and Robux shop visibility
- Trace shop teleports and shop folder discovery on the server
- Guard against double initialization of the ShopController so shop UIs stay open

## Testing
- `./rojo_bin/rojo build default.project.json -o out.rbxlx`
- `yes | ./aftman_bin/aftman install` *(fails: invalid peer certificate: UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d317a44832ea9637cd3f7f94f24