### PR TITLE
feat: join Pickfall until countdown ends

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickfallController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickfallController.lua
@@ -20,11 +20,15 @@ local guiFolder = player:WaitForChild("PlayerGui"):WaitForChild("PickFall")
 local gui       = guiFolder:WaitForChild("PickfallGui")
 local joinButton = gui:FindFirstChild("JoinButton") or gui:FindFirstChild("Inscribirse") or gui:FindFirstChildWhichIsA("TextButton")
 local stateLabel = gui:FindFirstChild("StateText") or gui:FindFirstChild("StatusLabel") or gui:FindFirstChildWhichIsA("TextLabel")
+local container = joinButton and joinButton.Parent or gui:FindFirstChildWhichIsA("Frame")
+
+local joined = false
 
 function PickfallController.init()
         if joinButton then
                 joinButton.MouseButton1Click:Connect(function()
                         JoinEvent:FireServer()
+                        joined = true
                         joinButton.Visible = false
                 end)
         end
@@ -33,14 +37,21 @@ function PickfallController.init()
                 if stateLabel then
                         if state == "idle" then
                                 stateLabel.Text = "Evento inactivo"
+                                joined = false
                                 if joinButton then joinButton.Visible = true end
                         elseif state == "countdown" then
-                                stateLabel.Text = string.format("Comienza en %ds", data or 0)
-                                if joinButton then joinButton.Visible = false end
+                                local t = tonumber(data) or 0
+                                local m = math.floor(t/60)
+                                local s = t%60
+                                stateLabel.Text = string.format("Pickfall empieza en %02d:%02d!", m, s)
+                                if joinButton then joinButton.Visible = not joined end
                         elseif state == "running" then
                                 stateLabel.Text = "Evento en progreso"
                                 if joinButton then joinButton.Visible = false end
                         end
+                end
+                if container then
+                        container.Visible = state ~= "running"
                 end
         end)
 
@@ -52,8 +63,12 @@ function PickfallController.init()
                                 stateLabel.Text = "Sin ganador"
                         end
                 end
+                joined = false
                 if joinButton then
                         joinButton.Visible = true
+                end
+                if container then
+                        container.Visible = true
                 end
         end)
 end


### PR DESCRIPTION
## Summary
- allow players to register for Pickfall until the countdown completes
- teleport registered players to arena spawns when the round starts
- show a countdown timer and hide the join button only after signing up

## Testing
- `rojo sourcemap default.project.json`
- `rojo build default.project.json -o /tmp/MiningGame.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_68b9cfb6fc4c832eb5c4eeb8fb4bb33b