### PR TITLE
feat: join Pickfall until countdown ends

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickfallController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickfallController.lua
@@ -3,6 +3,7 @@
 
 local Players           = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService        = game:GetService("RunService")
 
 local player = Players.LocalPlayer
 
@@ -20,42 +21,83 @@ local guiFolder = player:WaitForChild("PlayerGui"):WaitForChild("PickFall")
 local gui       = guiFolder:WaitForChild("PickfallGui")
 local joinButton = gui:FindFirstChild("JoinButton") or gui:FindFirstChild("Inscribirse") or gui:FindFirstChildWhichIsA("TextButton")
 local stateLabel = gui:FindFirstChild("StateText") or gui:FindFirstChild("StatusLabel") or gui:FindFirstChildWhichIsA("TextLabel")
+local container = joinButton and joinButton.Parent or gui:FindFirstChildWhichIsA("Frame")
+
+local joined = false
+local countdownConn, countdownTime
+
+local function updateCountdown()
+        if not stateLabel then return end
+        local m = math.floor(countdownTime/60)
+        local s = math.floor(countdownTime%60)
+        stateLabel.Text = string.format("Pickfall empieza en %02d:%02d!", m, s)
+end
 
 function PickfallController.init()
-        if joinButton then
-                joinButton.MouseButton1Click:Connect(function()
-                        JoinEvent:FireServer()
-                        joinButton.Visible = false
-                end)
-        end
+       if joinButton then
+               joinButton.MouseButton1Click:Connect(function()
+                       JoinEvent:FireServer()
+                       joined = true
+                       joinButton.Visible = false
+               end)
+       end
 
-        StateEvent.OnClientEvent:Connect(function(state, data)
-                if stateLabel then
-                        if state == "idle" then
-                                stateLabel.Text = "Evento inactivo"
-                                if joinButton then joinButton.Visible = true end
-                        elseif state == "countdown" then
-                                stateLabel.Text = string.format("Comienza en %ds", data or 0)
-                                if joinButton then joinButton.Visible = false end
-                        elseif state == "running" then
-                                stateLabel.Text = "Evento en progreso"
-                                if joinButton then joinButton.Visible = false end
-                        end
-                end
-        end)
+       StateEvent.OnClientEvent:Connect(function(state, data)
+               if state == "idle" then
+                       if countdownConn then
+                               countdownConn:Disconnect()
+                               countdownConn = nil
+                       end
+                       if stateLabel then
+                               stateLabel.Text = "Evento inactivo"
+                       end
+                       joined = false
+                       if joinButton then joinButton.Visible = true end
+               elseif state == "countdown" then
+                       countdownTime = tonumber(data) or 0
+                       updateCountdown()
+                       if not countdownConn then
+                               countdownConn = RunService.Heartbeat:Connect(function(dt)
+                                       countdownTime = math.max(0, countdownTime - dt)
+                                       updateCountdown()
+                               end)
+                       end
+                       if joinButton then joinButton.Visible = not joined end
+               elseif state == "running" then
+                       if countdownConn then
+                               countdownConn:Disconnect()
+                               countdownConn = nil
+                       end
+                       if stateLabel then
+                               stateLabel.Text = "Evento en progreso"
+                       end
+                       if joinButton then joinButton.Visible = false end
+               end
+               if container then
+                       container.Visible = state ~= "running"
+               end
+       end)
 
-        WinnerEvent.OnClientEvent:Connect(function(name)
-                if stateLabel then
-                        if name and name ~= "" then
-                                stateLabel.Text = name .. " ganó!"
-                        else
-                                stateLabel.Text = "Sin ganador"
-                        end
-                end
-                if joinButton then
-                        joinButton.Visible = true
-                end
-        end)
+       WinnerEvent.OnClientEvent:Connect(function(name)
+               if countdownConn then
+                       countdownConn:Disconnect()
+                       countdownConn = nil
+               end
+               if stateLabel then
+                       if name and name ~= "" then
+                               stateLabel.Text = name .. " ganó!"
+                       else
+                               stateLabel.Text = "Sin ganador"
+                       end
+               end
+               joined = false
+               if joinButton then
+                       joinButton.Visible = true
+               end
+               if container then
+                       container.Visible = true
+               end
+       end)
 end
 
 return PickfallController


### PR DESCRIPTION
## Summary
- allow players to register for Pickfall until the countdown completes
- teleport registered players to arena spawns when the round starts
- show a countdown timer and hide the join button only after signing up
- update countdown locally so the timer ticks down correctly

## Testing
- `rojo sourcemap default.project.json`
- `rojo build default.project.json -o /tmp/MiningGame.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_68b9cfb6fc4c832eb5c4eeb8fb4bb33b