### PR TITLE
Fix mining server event validation crash

### DIFF
--- a/src/ServerScriptService/Scripts/MiningServer.server.lua
+++ b/src/ServerScriptService/Scripts/MiningServer.server.lua
@@ -84,7 +84,14 @@ DebounceRF.OnServerInvoke = function(player, object)
 end
 
 SubtractHealthRE.OnServerEvent:Connect(function(player, object, healthSubtraction)
-ayer or typeof(object) ~= "Instance" or not object.Parent then return end
+    -- Validate parameters and basic conditions before processing the hit.
+    -- The previous version of this line was accidentally truncated, causing a
+    -- syntax error that stopped the entire server script from running.  This
+    -- meant remote events were never handled, breaking highlights, crystal
+    -- mining and sounds.  Restoring the full conditional fixes the issue.
+    if not player or typeof(object) ~= "Instance" or not object.Parent then
+        return
+    end
     if Debounce[player] then return end
     if not isMinable(object) then return end
     if not inRange(player, object) then return end


### PR DESCRIPTION
## Summary
- fix truncated parameter validation in `MiningServer.server.lua`
- ensures mining events process properly for highlights, crystals, sounds, and auto-mining

## Testing
- `./rojo-bin/rojo build -o build.rbxm`

------
https://chatgpt.com/codex/tasks/task_e_68b9eb50aec0832e987d9b954a0a1673