### PR TITLE
Disable Rojo ignoreUnknownInstances and map all instances

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -3,10 +3,11 @@
   "servePlaceIds": [ 116227459207208 ],
   "tree": {
     "$className": "DataModel",
+    "$ignoreUnknownInstances": false,
 
     "Workspace": {
       "$className": "Workspace",
-      "$ignoreUnknownInstances": true,
+      "$ignoreUnknownInstances": false,
 
       "Plots":             { "$path": "src/Workspace/Plots.rbxmx" },
       "SpawnLocation":     { "$path": "src/Workspace/SpawnLocation.rbxmx" },
@@ -15,7 +16,11 @@
       "TiendaPico":        { "$path": "src/Workspace/TiendaPico.rbxmx" },
       "Shops":            { "$path": "src/Workspace/Shops.rbxmx" },
       "Baseplate":         { "$path": "src/Workspace/Baseplate.rbxmx" },
-      "PickaxeBasic":      { "$path": "src/Workspace/PickaxeBasic.rbxmx" }
+      "PickaxeBasic":      { "$path": "src/Workspace/PickaxeBasic.rbxmx" },
+      "Lights":            { "$path": "src/Workspace/Lights.rbxmx" },
+      "PickfallArena":     { "$path": "src/Workspace/PickfallArena.rbxmx" },
+      "Camera":            { "$className": "Camera" },
+      "Terrain":           { "$className": "Terrain" }
     },
 
     "ServerScriptService": {
@@ -31,13 +36,14 @@
 
     "ServerStorage": {
       "$className": "ServerStorage",
-      "$ignoreUnknownInstances": true,
-      "NodeTemplates": { "$path": "src/ServerStorage/NodeTemplates.rbxmx" }
+      "$ignoreUnknownInstances": false,
+      "NodeTemplates": { "$path": "src/ServerStorage/NodeTemplates.rbxmx" },
+      "TagList":       { "$path": "src/ServerStorage/TagList.rbxmx" }
     },
 
     "ReplicatedStorage": {
       "$className": "ReplicatedStorage",
-      "$ignoreUnknownInstances": true,
+      "$ignoreUnknownInstances": false,
 
       "Remotes":      { "$path": "src/ReplicatedStorage/Remotes.rbxmx" },
       "Shared":       { "$path": "src/ReplicatedStorage/Shared" },
@@ -48,16 +54,22 @@
 
     "StarterPlayer": {
       "$className": "StarterPlayer",
+      "$ignoreUnknownInstances": false,
       "StarterPlayerScripts": {
         "$className": "StarterPlayerScripts",
-        "$ignoreUnknownInstances": true,
+        "$ignoreUnknownInstances": false,
         "$path": "src/StarterPlayer/StarterPlayerScripts"
+      },
+      "StarterCharacterScripts": {
+        "$className": "StarterCharacterScripts",
+        "$ignoreUnknownInstances": false,
+        "$path": "src/StarterPlayer/StarterCharacterScripts"
       }
     },
 
     "StarterGui": {
       "$className": "StarterGui",
-      "$ignoreUnknownInstances": true,
+      "$ignoreUnknownInstances": false,
       "MainGui":        { "$path": "src/StarterGui/MainGui.rbxmx" },
       "PlayerStatsGui": { "$path": "src/StarterGui/PlayerStatsGui.rbxmx" },
       "SaleDialog":    { "$path": "src/StarterGui/SaleDialog.rbxmx" },


### PR DESCRIPTION
## Summary
- Set `$ignoreUnknownInstances` to false across the project tree
- Added workspace assets (Lights, PickfallArena, Camera, Terrain) and ServerStorage TagList to `default.project.json`
- Introduced `StarterCharacterScripts` folder to keep starter assets complete

## Testing
- `rojo --version` *(fails: command not found)*
- `curl -L https://github.com/rojo-rbx/rojo/releases/download/v7.4.1/rojo-v7.4.1-linux.zip -o rojo.zip` *(fails: Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f7c47d90832eb017c524bd6318d4