### PR TITLE
Fix MiningService path in PickfallEventService

### DIFF
--- a/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
+++ b/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
@@ -14,7 +14,10 @@ local StateEvent     = PickfallFolder:WaitForChild("PickfallState")
 local WinnerEvent    = PickfallFolder:WaitForChild("PickfallWinner")
 
 
-local MiningService = require(script.Parent:WaitForChild("MiningService"))
+-- MiningService no está ubicado dentro de la carpeta `PickFall`, por lo que debemos
+-- buscarlo en el directorio padre. Anteriormente se esperaba que fuese un hijo
+-- directo, provocando un `infinite yield` al no encontrarlo.
+local MiningService = require(script.Parent.Parent:WaitForChild("MiningService"))
 
 local arena  = Workspace:WaitForChild("PickfallArena")
 local base   = arena:WaitForChild("Base")


### PR DESCRIPTION
## Summary
- fix PickfallEventService requiring MiningService from wrong directory

## Testing
- `./rojo_bin/rojo build -o test.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_68ba0df9c6bc832ea7abfdb82f1292e3