### PR TITLE
Extend Pickfall ores to use arena templates

### DIFF
--- a/src/ServerScriptService/Services/MiningService.lua
+++ b/src/ServerScriptService/Services/MiningService.lua
@@ -141,9 +141,9 @@ local function mineStone(player, model: Model)
 	local l = ensureLimiters(player)
 	if not l.stone:allow(1) then return end
 
-	if typeof(model) ~= "Instance" or not model:IsA("Model") then return end
-	if not hasTagDeep(model, "Stone") then return end
-	if not ownsPlotForModel(player, model) then return end
+        if typeof(model) ~= "Instance" or not model:IsA("Model") then return end
+        if not hasTagDeep(model, "Stone") and not model:GetAttribute("IsMinable") then return end
+        if not ownsPlotForModel(player, model) then return end
 
 	local focus = focusPart(model)
 	if not (focus and distOK(player, focus)) then return end

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
@@ -62,13 +62,18 @@ end
 local function nodeInfoFrom(model)
     if not (model and model:IsA("Model")) then return nil end
     local attr = model:GetAttribute("NodeType")
-    if attr == "CommonStone" or attr == "Stone" then
-        return "Stone", focusPart(model)
-    elseif attr == "Crystal" then
-        return "Crystal", focusPart(model)
+    if attr then
+        if attr == "Crystal" then
+            return "Crystal", focusPart(model)
+        else
+            return "Stone", focusPart(model)
+        end
     end
-    if hasTagDeep(model, "Stone")   then return "Stone",   focusPart(model) end
+    if model:GetAttribute("IsMinable") then
+        return "Stone", focusPart(model)
+    end
     if hasTagDeep(model, "Crystal") then return "Crystal", focusPart(model) end
+    if hasTagDeep(model, "Stone") then return "Stone", focusPart(model) end
     return nil
 end
 


### PR DESCRIPTION
## Summary
- Spawn Pickfall event ores from arena `Ores` folder
- Handle generic ore models in mining controllers and services

## Testing
- `./rojo_bin/rojo build -o build.rbxlx`

------
https://chatgpt.com/codex/tasks/task_e_68ba1b4e6acc832eaee1da27fd7ff38b