### PR TITLE
fix: define resetOreBlocks for Pickfall arena

### DIFF
--- a/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
+++ b/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
@@ -104,6 +104,24 @@ local function setupOreBlocks()
 
 end
 
+-- Reset the Pickfall arena's ore blocks.
+--
+-- The previous implementation referenced a `resetOreBlocks` function that
+-- did not exist, causing a runtime error when the service started.  This
+-- function rebuilds the ore platforms and registers any new ore models with
+-- `NodeService` so that mining interactions work correctly.
+local function resetOreBlocks()
+  -- Generate a fresh set of ore blocks
+  setupOreBlocks()
+
+  -- Register ore models with NodeService for mining behaviour
+  for _, ore in ipairs(oreFolder:GetChildren()) do
+    if ore:IsA("Model") then
+      NodeService.register(ore)
+    end
+  end
+end
+
 local function broadcast(state, data)
         print("[PickfallEventService] broadcast", state, data)
         currentState, currentData = state, data


### PR DESCRIPTION
## Summary
- implement missing `resetOreBlocks` to rebuild and register ore blocks, preventing nil call

## Testing
- `./rojo7/rojo sourcemap default.project.json -o /tmp/sourcemap.json`


------
https://chatgpt.com/codex/tasks/task_e_68ba23ab6db4832eab6b4e9903376ada