### PR TITLE
Handle Spanish pickaxe names

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
@@ -92,8 +92,11 @@ local function hasEquippedPickaxeClient()
     if not ch then return false end
     if ch:FindFirstChild("PickaxeModel") then return true end
     for _, inst in ipairs(ch:GetChildren()) do
-        if inst:IsA("Tool") and (inst.Name:lower():find("pick") or CollectionService:HasTag(inst, "Pickaxe")) then
-            return true
+        if inst:IsA("Tool") then
+            local lname = inst.Name:lower()
+            if lname:find("pick") or lname:find("pico") or CollectionService:HasTag(inst, "Pickaxe") then
+                return true
+            end
         end
     end
     local flag = player:FindFirstChild("PickaxeEquipped")


### PR DESCRIPTION
## Summary
- Detect tools named with Spanish term "pico" as pickaxes so mining works for them

## Testing
- `rojo sourcemap default.project.json`

------
https://chatgpt.com/codex/tasks/task_e_68ba26dc0be4832ea0fcd50a01d3b1ff