### PR TITLE
Handle Spanish pickaxe names

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/InputController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/InputController.lua
@@ -34,6 +34,16 @@ end
 
 local function isStoneModel(model: Model?): boolean
 	if not (model and model:IsA("Model")) then return false end
+
+	local nodeType = model:GetAttribute("NodeType")
+	if nodeType then
+		nodeType = string.lower(tostring(nodeType))
+		if nodeType:find("stone", 1, true) then return true end
+		if nodeType == "crystal" then return false end
+	end
+	if model:GetAttribute("IsMinable") and not nodeType then
+		return true
+	end
 	if CollectionService:HasTag(model, "Stone") then return true end
 	if model.PrimaryPart and CollectionService:HasTag(model.PrimaryPart, "Stone") then return true end
 	local hit = model:FindFirstChild("Hitbox")
@@ -70,13 +80,23 @@ local function fireMine(model: Model)
 end
 
 local function tryMineFromPart(part: Instance)
-	if not part then return end
+	if not part then
+		warn("[InputController] click sin target")
+		return
+	end
 	local model = part:FindFirstAncestorOfClass("Model")
-	if not isStoneModel(model) then return end
+	if not isStoneModel(model) then
+		warn("[InputController] objetivo no minable", model and model.Name)
+		return
+	end
 
 	local focus = focusPart(model)
-	if not (focus and distOK(focus)) then return end
+	if not (focus and distOK(focus)) then
+		warn("[InputController] fuera de rango", model and model.Name)
+		return
+	end
 
+	warn("[InputController] enviando MiningRequest", model.Name)
 	fireMine(model)
 end
 

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
@@ -89,15 +89,28 @@ end
 
 local function hasEquippedPickaxeClient()
     local ch = player.Character
-    if not ch then return false end
-    if ch:FindFirstChild("PickaxeModel") then return true end
+    if not ch then
+        warn("[MiningController] hasEquippedPickaxeClient: sin character")
+        return false
+    end
+    if ch:FindFirstChild("PickaxeModel") then
+        warn("[MiningController] hasEquippedPickaxeClient: PickaxeModel detectado")
+        return true
+    end
     for _, inst in ipairs(ch:GetChildren()) do
-        if inst:IsA("Tool") and (inst.Name:lower():find("pick") or CollectionService:HasTag(inst, "Pickaxe")) then
-            return true
+        if inst:IsA("Tool") then
+            local lname = inst.Name:lower()
+            warn("[MiningController] Revisando herramienta", inst.Name)
+            if lname:find("pick") or lname:find("pico") or CollectionService:HasTag(inst, "Pickaxe") then
+                warn("[MiningController] hasEquippedPickaxeClient: reconocida como pico", inst.Name)
+                return true
+            end
         end
     end
     local flag = player:FindFirstChild("PickaxeEquipped")
-    return (flag and flag.Value) or false
+    local equipped = (flag and flag.Value) or false
+    warn("[MiningController] hasEquippedPickaxeClient: flag PickaxeEquipped=", equipped)
+    return equipped
 end
 
 local function nodeIdOf(model)
@@ -249,9 +262,14 @@ function M:start(_, SoundManager)
         local nodeType, focus = nodeInfoFrom(model)
 
         if nodeType == "Stone" then
-            local canMine = focus and distOK(focus)
+            local inDist  = focus and distOK(focus)
+            local canMine = inDist
             setHighlight(model, canMine)
+            if not canMine and model then
+                warn("[MiningController] Piedra fuera de rango", model.Name, "inDist=", inDist)
+            end
             if canMine then
+                warn("[MiningController] Piedra lista para minar", model.Name)
                 currentStone = model
                 updateMiningGUI(model)
             else
@@ -263,6 +281,7 @@ function M:start(_, SoundManager)
                 lastStoneAuto = time()
                 local id = nodeIdOf(model)
                 if id then
+                    warn("[MiningController] Enviando MiningRequest", model.Name, id)
                     EventBus.sendToServer(Topics.MiningRequest, { node = model, nodeId = id, toolTier = 1 })
                 end
             end
@@ -274,6 +293,7 @@ function M:start(_, SoundManager)
             local hasPick = hasEquippedPickaxeClient()
             local inDist  = focus and distOK(focus)
             local canMine = hasPick and inDist
+            warn("[MiningController] Cristal check hasPick=", hasPick, "inDist=", inDist, model and model.Name)
             setHighlight(model, canMine)
 
             local hoverAllowed  = ownsAutoMinePass() and autoMineEnabled()
@@ -283,6 +303,7 @@ function M:start(_, SoundManager)
                 pendingModel = model
                 local id = nodeIdOf(model)
                 if id then
+                    warn("[MiningController] Enviando MiningCrystalStart", model.Name, id)
                     EventBus.sendToServer(Topics.MiningCrystalStart, { node = model, nodeId = id })
                 end
             end
@@ -293,6 +314,7 @@ function M:start(_, SoundManager)
             end
 
             if (not shouldContinue) and (pendingModel or miningActive) then
+                warn("[MiningController] MiningCrystalStop")
                 EventBus.sendToServer(Topics.MiningCrystalStop, {})
                 if currentCrystal then clearCrystalProgress(currentCrystal) end
                 currentCrystal, miningActive, pendingModel = nil, false, nil


### PR DESCRIPTION
## Summary
- Detect tools named with Spanish term "pico" as pickaxes so mining works for them
- Add detailed debug logs to mining controller to trace pickaxe detection and mining events
- Recognize ores via attributes and log mining attempts, allowing mining of untagged ore parts

## Testing
- `rojo sourcemap default.project.json`


------
https://chatgpt.com/codex/tasks/task_e_68ba26dc0be4832ea0fcd50a01d3b1ff