### PR TITLE
Allow mining of standalone ore parts

### DIFF
--- a/src/ServerScriptService/Services/MiningService.lua
+++ b/src/ServerScriptService/Services/MiningService.lua
@@ -51,22 +51,25 @@ local function distOK(player, part)
 	return (hrp and part) and ((hrp.Position - part.Position).Magnitude <= MAX_DISTANCE) or false
 end
 
-local function hasTagDeep(model: Model, tag: string): boolean
-	if CollectionService:HasTag(model, tag) then return true end
-	if model.PrimaryPart and CollectionService:HasTag(model.PrimaryPart, tag) then return true end
-	for _, d in ipairs(model:GetDescendants()) do
-		if d:IsA("BasePart") and CollectionService:HasTag(d, tag) then
-			return true
-		end
-	end
-	return false
+local function hasTagDeep(inst: Instance, tag: string): boolean
+        if CollectionService:HasTag(inst, tag) then return true end
+        if inst:IsA("Model") then
+                if inst.PrimaryPart and CollectionService:HasTag(inst.PrimaryPart, tag) then return true end
+                for _, d in ipairs(inst:GetDescendants()) do
+                        if d:IsA("BasePart") and CollectionService:HasTag(d, tag) then
+                                return true
+                        end
+                end
+        end
+        return false
 end
 
-local function focusPart(model: Model?): BasePart?
-	if not model then return nil end
-	local hit = model:FindFirstChild("Hitbox")
-	if hit and hit:IsA("BasePart") then return hit end
-	return model.PrimaryPart or model:FindFirstChildWhichIsA("BasePart", true)
+local function focusPart(inst: Instance?): BasePart?
+        if not inst then return nil end
+        if inst:IsA("BasePart") then return inst end
+        local hit = inst:FindFirstChild("Hitbox")
+        if hit and hit:IsA("BasePart") then return hit end
+        return inst.PrimaryPart or inst:FindFirstChildWhichIsA("BasePart", true)
 end
 
 local function ownsPlotForModel(player, model)
@@ -114,17 +117,16 @@ local function buffMultiplier(player: Player)
         return 1
 end
 
--- coerce payload → Model con NodeService
-local function coerceNode(payload): Model?
+-- coerce payload → Instance con NodeService
+local function coerceNode(payload): Instance?
         if typeof(payload) ~= "table" then
-                print("[MiningService] coerceNode invalid payload", payload)
                 return nil
         end
 
         local inst = payload.node
         local id   = payload.nodeId
 
-        if typeof(inst) == "Instance" and inst:IsA("Model") then
+        if typeof(inst) == "Instance" and (inst:IsA("Model") or inst:IsA("BasePart")) then
                 return inst
         end
 
@@ -133,91 +135,92 @@ local function coerceNode(payload): Model?
                 if byIdx then return byIdx end
 
                 local byName = Workspace:FindFirstChild(id, true)
-                if byName and byName:IsA("Model") then return byName end
+                if byName and (byName:IsA("Model") or byName:IsA("BasePart")) then return byName end
         end
 
-        print("[MiningService] coerceNode could not resolve node", payload)
         return nil
 end
 
 -- ========= Piedras =========
-local function mineStone(player, model: Model)
-        print("[MiningService] mineStone player=", player and player.Name, "model=", model and model.Name)
+local function mineStone(player, model: Instance)
         local l = ensureLimiters(player)
         if not l.stone:allow(1) then
-                print("\tRate limited")
                 return
         end
 
-        if typeof(model) ~= "Instance" or not model:IsA("Model") then
-                print("\tInvalid model", model)
+        if typeof(model) ~= "Instance" or not (model:IsA("Model") or model:IsA("BasePart")) then
                 return
         end
         local hasStoneTag = hasTagDeep(model, "Stone")
         local isMinable = model:GetAttribute("IsMinable")
         if not hasStoneTag and not isMinable then
-                print("\tNot minable", model.Name, "StoneTag=", hasStoneTag, "IsMinable=", isMinable)
                 return
         end
         if not ownsPlotForModel(player, model) then
-                print("\tPlayer does not own model", model.Name)
                 return
         end
 
 
         local focus = focusPart(model)
         if not (focus and distOK(player, focus)) then
-                print("\tDistance check failed for", model.Name)
                 return
         end
 
-        local add = hasPickaxeServer(player) and 2 or 1
-        add = add * buffMultiplier(player)
-        DataService.addResource(player, "stones", add)
+        local maxH = tonumber(model:GetAttribute("MaxHealth")) or 1
+        local current = tonumber(model:GetAttribute("Health")) or maxH
+        local dmg = hasPickaxeServer(player) and 2 or 1
+        dmg = dmg * buffMultiplier(player)
+        local newHealth = math.max(0, current - dmg)
+        model:SetAttribute("Health", newHealth)
 
-        EventBus.sendToClient(player, Topics.MiningFeedback, {
-                kind = "stone",
-                position = focus.Position,
-        })
-        -- efectos de partículas al romper la roca
-        local fx = model:FindFirstChild("FxStone", true)
-        if fx and fx:IsA("Attachment") then
-                local parent = fx.Parent
-                if parent and parent:IsA("BasePart") then
-                        local anchor = Instance.new("Part")
-                        anchor.Name = "FxStoneAnchor"
-                        anchor.Anchored = true
-                        anchor.CanCollide = false
-                        anchor.Transparency = 1
-                        anchor.Size = Vector3.new(0.1,0.1,0.1)
-                        anchor.CFrame = fx.WorldCFrame
+        if newHealth <= 0 then
+                local reward = tonumber(model:GetAttribute("Reward")) or dmg
+                DataService.addResource(player, "stones", reward * buffMultiplier(player))
 
-                        local clone = fx:Clone()
-                        clone.Parent = anchor
-                        anchor.Parent = Workspace
+                EventBus.sendToClient(player, Topics.MiningFeedback, {
+                        kind = "stone",
+                        position = focus.Position,
+                })
+                -- efectos de partículas al romper la roca
+                local fx = model:FindFirstChild("FxStone", true)
+                if fx and fx:IsA("Attachment") then
+                        local parent = fx.Parent
+                        if parent and parent:IsA("BasePart") then
+                                local anchor = Instance.new("Part")
+                                anchor.Name = "FxStoneAnchor"
+                                anchor.Anchored = true
+                                anchor.CanCollide = false
+                                anchor.Transparency = 1
+                                anchor.Size = Vector3.new(0.1,0.1,0.1)
+                                anchor.CFrame = fx.WorldCFrame
 
-                        for _, emitter in ipairs(clone:GetChildren()) do
-                                if emitter:IsA("ParticleEmitter") then
+                                local clone = fx:Clone()
+                                clone.Parent = anchor
+                                anchor.Parent = Workspace
 
-                                        local prevRate = emitter.Rate
-                                        emitter.Enabled = true
-                                        if emitter.Rate <= 0 then
-                                                emitter.Rate = 20
+                                for _, emitter in ipairs(clone:GetChildren()) do
+                                        if emitter:IsA("ParticleEmitter") then
+
+                                                local prevRate = emitter.Rate
+                                                emitter.Enabled = true
+                                                if emitter.Rate <= 0 then
+                                                        emitter.Rate = 20
+                                                end
+                                                emitter:Emit(15)
+                                                task.delay(0.5, function()
+                                                        emitter.Enabled = false
+                                                        emitter.Rate = prevRate
+                                                end)
+
                                         end
-                                        emitter:Emit(15)
-                                        task.delay(0.5, function()
-                                                emitter.Enabled = false
-                                                emitter.Rate = prevRate
-                                        end)
-
                                 end
+
+                                Debris:AddItem(anchor, 2)
                         end
-
-                        Debris:AddItem(anchor, 2)
                 end
-        end
 
-        if model.Parent then model:Destroy() end
+                if model.Parent then model:Destroy() end
+        end
 end
 
 -- ========= Cristales =========
@@ -315,7 +318,6 @@ function MiningService.init()
 		stopCrystal(player)
 	end)
 
-	print("[MiningService] Initialized (clean EventBus only).")
 end
 
 function MiningService.ApplyMiningBuff(player: Player, duration: number, multiplier: number)

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/InputController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/InputController.lua
@@ -25,25 +25,38 @@ local function distOK(part)
 	return (root and part) and ((root.Position - part.Position).Magnitude <= MAX_DISTANCE) or false
 end
 
-local function focusPart(model: Model?)
-	if not model then return nil end
-	local hit = model:FindFirstChild("Hitbox")
-	if hit and hit:IsA("BasePart") then return hit end
-	return model.PrimaryPart or model:FindFirstChildWhichIsA("BasePart", true)
+local function focusPart(inst: Instance?)
+        if not inst then return nil end
+        if inst:IsA("BasePart") then return inst end
+        local hit = inst:FindFirstChild("Hitbox")
+        if hit and hit:IsA("BasePart") then return hit end
+        return inst.PrimaryPart or inst:FindFirstChildWhichIsA("BasePart", true)
 end
 
-local function isStoneModel(model: Model?): boolean
-	if not (model and model:IsA("Model")) then return false end
-	if CollectionService:HasTag(model, "Stone") then return true end
-	if model.PrimaryPart and CollectionService:HasTag(model.PrimaryPart, "Stone") then return true end
-	local hit = model:FindFirstChild("Hitbox")
-	if hit and hit:IsA("BasePart") and CollectionService:HasTag(hit, "Stone") then return true end
-	for _, d in ipairs(model:GetDescendants()) do
-		if d:IsA("BasePart") and CollectionService:HasTag(d, "Stone") then
-			return true
-		end
-	end
-	return false
+local function isStoneModel(model: Instance?): boolean
+        if not (model and (model:IsA("Model") or model:IsA("BasePart"))) then return false end
+
+        local nodeType = model:GetAttribute("NodeType")
+        if nodeType then
+                nodeType = string.lower(tostring(nodeType))
+                if nodeType:find("stone", 1, true) then return true end
+                if nodeType == "crystal" then return false end
+        end
+        if model:GetAttribute("IsMinable") then
+                return true
+        end
+        if CollectionService:HasTag(model, "Stone") then return true end
+        if model:IsA("Model") then
+                if model.PrimaryPart and CollectionService:HasTag(model.PrimaryPart, "Stone") then return true end
+                local hit = model:FindFirstChild("Hitbox")
+                if hit and hit:IsA("BasePart") and CollectionService:HasTag(hit, "Stone") then return true end
+                for _, d in ipairs(model:GetDescendants()) do
+                        if d:IsA("BasePart") and CollectionService:HasTag(d, "Stone") then
+                                return true
+                        end
+                end
+        end
+        return false
 end
 
 local function raycastFromScreen(screenPos: Vector2)
@@ -60,24 +73,33 @@ local function raycastFromScreen(screenPos: Vector2)
 	return result and result.Instance or nil
 end
 
-local function fireMine(model: Model)
-	local id = model:GetAttribute("NodeId") or model.Name
-	EventBus.sendToServer(Topics.MiningRequest, {
-		node   = model,
-		nodeId = id,
-		toolTier = 1,
-	})
+local function fireMine(model: Instance)
+        local id = model:GetAttribute("NodeId") or model.Name
+        EventBus.sendToServer(Topics.MiningRequest, {
+                node   = model,
+                nodeId = id,
+                toolTier = 1,
+        })
 end
 
 local function tryMineFromPart(part: Instance)
-	if not part then return end
-	local model = part:FindFirstAncestorOfClass("Model")
-	if not isStoneModel(model) then return end
+        if not part then
+                return
+        end
+        local model = part:FindFirstAncestorOfClass("Model")
+        if not model and part:IsA("BasePart") then
+                model = part
+        end
+        if not isStoneModel(model) then
+                return
+        end
 
-	local focus = focusPart(model)
-	if not (focus and distOK(focus)) then return end
+        local focus = focusPart(model)
+        if not (focus and distOK(focus)) then
+                return
+        end
 
-	fireMine(model)
+        fireMine(model)
 end
 
 -- PC + móvil

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
@@ -41,39 +41,42 @@ local function distOK(part)
     return (root and part) and ((root.Position - part.Position).Magnitude <= MAX_DISTANCE) or false
 end
 
-local function hasTagDeep(model, tag)
-    if CollectionService:HasTag(model, tag) then return true end
-    if model.PrimaryPart and CollectionService:HasTag(model.PrimaryPart, tag) then return true end
-    for _, d in ipairs(model:GetDescendants()) do
-        if d:IsA("BasePart") and CollectionService:HasTag(d, tag) then
-            return true
+local function hasTagDeep(inst, tag)
+    if CollectionService:HasTag(inst, tag) then return true end
+    if inst:IsA("Model") then
+        if inst.PrimaryPart and CollectionService:HasTag(inst.PrimaryPart, tag) then return true end
+        for _, d in ipairs(inst:GetDescendants()) do
+            if d:IsA("BasePart") and CollectionService:HasTag(d, tag) then
+                return true
+            end
         end
     end
     return false
 end
 
-local function focusPart(model)
-    if not model then return nil end
-    local hit = model:FindFirstChild("Hitbox")
+local function focusPart(inst)
+    if not inst then return nil end
+    if inst:IsA("BasePart") then return inst end
+    local hit = inst:FindFirstChild("Hitbox")
     if hit and hit:IsA("BasePart") then return hit end
-    return model.PrimaryPart or model:FindFirstChildWhichIsA("BasePart", true)
+    return inst.PrimaryPart or inst:FindFirstChildWhichIsA("BasePart", true)
 end
 
-local function nodeInfoFrom(model)
-    if not (model and model:IsA("Model")) then return nil end
-    local attr = model:GetAttribute("NodeType")
+local function nodeInfoFrom(inst)
+    if not inst then return nil end
+    local attr = inst:GetAttribute("NodeType")
     if attr then
         if attr == "Crystal" then
-            return "Crystal", focusPart(model)
+            return "Crystal", focusPart(inst)
         else
-            return "Stone", focusPart(model)
+            return "Stone", focusPart(inst)
         end
     end
-    if model:GetAttribute("IsMinable") then
-        return "Stone", focusPart(model)
+    if inst:GetAttribute("IsMinable") then
+        return "Stone", focusPart(inst)
     end
-    if hasTagDeep(model, "Crystal") then return "Crystal", focusPart(model) end
-    if hasTagDeep(model, "Stone") then return "Stone", focusPart(model) end
+    if hasTagDeep(inst, "Crystal") then return "Crystal", focusPart(inst) end
+    if hasTagDeep(inst, "Stone") then return "Stone", focusPart(inst) end
     return nil
 end
 
@@ -89,11 +92,18 @@ end
 
 local function hasEquippedPickaxeClient()
     local ch = player.Character
-    if not ch then return false end
-    if ch:FindFirstChild("PickaxeModel") then return true end
+    if not ch then
+        return false
+    end
+    if ch:FindFirstChild("PickaxeModel") then
+        return true
+    end
     for _, inst in ipairs(ch:GetChildren()) do
-        if inst:IsA("Tool") and (inst.Name:lower():find("pick") or CollectionService:HasTag(inst, "Pickaxe")) then
-            return true
+        if inst:IsA("Tool") then
+            local lname = inst.Name:lower()
+            if lname:find("pick") or lname:find("pico") or CollectionService:HasTag(inst, "Pickaxe") then
+                return true
+            end
         end
     end
     local flag = player:FindFirstChild("PickaxeEquipped")
@@ -245,11 +255,12 @@ function M:start(_, SoundManager)
 
     RunService.RenderStepped:Connect(function()
         local target = mouse.Target
-        local model  = target and target:FindFirstAncestorOfClass("Model") or nil
+        local model  = target and (target:FindFirstAncestorOfClass("Model") or target) or nil
         local nodeType, focus = nodeInfoFrom(model)
 
         if nodeType == "Stone" then
-            local canMine = focus and distOK(focus)
+            local inDist  = focus and distOK(focus)
+            local canMine = inDist
             setHighlight(model, canMine)
             if canMine then
                 currentStone = model


### PR DESCRIPTION
## Summary
- Handle base parts as valid nodes when they carry `IsMinable` or stone tags
- Permit server-side mining of non-model ore parts via relaxed node checks
- Show mining GUI for base-part ores and track their individual health before rewarding and destroying
- Remove temporary debug logging from mining scripts

## Testing
- `./rojo-bin/rojo sourcemap default.project.json`


------
https://chatgpt.com/codex/tasks/task_e_68ba26dc0be4832ea0fcd50a01d3b1ff