### PR TITLE
chore: remove mining debug logs

### DIFF
--- a/src/ServerScriptService/ServerModules/Plot/NodeSpawner.lua
+++ b/src/ServerScriptService/ServerModules/Plot/NodeSpawner.lua
@@ -198,7 +198,6 @@ local function spawnNode(plotData, nodeType)
                 plotData.crystals[node] = true
         end
 
-        dprint(("Spawned %s en '%s' (%s)"):format(nodeType, usedZone or "?", plotData.model.Name))
         return true
 end
 

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
@@ -266,11 +266,7 @@ function M:start(_, SoundManager)
             local inDist  = focus and distOK(focus)
             local canMine = inDist
             setHighlight(model, canMine)
-            if not canMine and model then
-                warn("[MiningController] Piedra fuera de rango", model.Name, "inDist=", inDist)
-            end
             if canMine then
-                warn("[MiningController] Piedra lista para minar", model.Name)
                 currentStone = model
                 updateMiningGUI(model)
             else


### PR DESCRIPTION
## Summary
- remove MiningController log when stone is ready to mine
- drop NodeSpawner spawn log
- strip MiningController out-of-range warning

## Testing
- `rojo build default.project.json -o place.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_68ba328cea80832e9703a8c9840091e7