### PR TITLE
Restrict Pickfall ores to pickaxe use

### DIFF
--- a/src/ServerScriptService/Services/MiningService.lua
+++ b/src/ServerScriptService/Services/MiningService.lua
@@ -153,6 +153,11 @@ local function mineStone(player, model: Instance)
                 return
         end
 
+        local requiresPickaxe = model:GetAttribute("RequiresPickaxe")
+        if requiresPickaxe and not hasPickaxeServer(player) then
+                return
+        end
+
         local focus = focusPart(model)
         if not (focus and distOK(player, focus)) then
                 return

--- a/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
+++ b/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
@@ -47,6 +47,8 @@ local function setupOreBlocks()
     ore:SetAttribute("MaxHealth", mh)
     ore:SetAttribute("Health", ore:GetAttribute("Health") or mh)
     ore:SetAttribute("IsMinable", true)
+    ore:SetAttribute("Reward", 0)
+    ore:SetAttribute("RequiresPickaxe", true)
 
     if ore:IsA("Model") then
       for _, part in ipairs(ore:GetDescendants()) do


### PR DESCRIPTION
## Summary
- Require a pickaxe to mine Pickfall arena ore blocks
- Prevent Pickfall ore blocks from rewarding stones

## Testing
- `rojo --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba43cf9760832e81f7b19a846aa1ca