### PR TITLE
fix: bind Pickfall countdown label and join button

### DIFF
--- a/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
+++ b/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
@@ -21,7 +21,7 @@ local oreFolder = arena:WaitForChild("OrePlatforms") -- updated name from "Ores"
 local spawns    = arena:WaitForChild("Spawners")
 
 local ROUND_INTERVAL = 300 
-local COUNTDOWN      = 10
+local COUNTDOWN      = 30
 local MONEY_REWARD   = 100
 local BUFF_DURATION  = 60
 local BUFF_MULT      = 2
@@ -83,6 +83,7 @@ local function broadcast(state, data)
 end
 
 local function resetAll()
+        print("[PickfallEventService] resetAll")
         for plr, info in pairs(participants) do
                 local char = plr.Character
                 if char and info.startCFrame then
@@ -95,19 +96,21 @@ local function resetAll()
         participants = {}
         active = false
         resetOreBlocks()
+        print("[PickfallEventService] resetAll complete")
 
 end
 
 local function reward(plr)
-
         if not plr then return end
+        print("[PickfallEventService] reward", plr.Name)
         WinnerEvent:FireAllClients(plr.Name)
         local stats = plr:FindFirstChild("leaderstats")
         local money = stats and stats:FindFirstChild("Money")
         if money then
-
                 money.Value = money.Value + MONEY_REWARD
-
+                print("\tMoney awarded", MONEY_REWARD)
+        else
+                print("\tMoney stat missing")
         end
         MiningService.ApplyMiningBuff(plr, BUFF_DURATION, BUFF_MULT)
 end
@@ -115,17 +118,17 @@ end
 local function checkWin()
         local count, last = 0, nil
         for plr in pairs(participants) do
-
                 count = count + 1
-
                 last = plr
         end
+        print("[PickfallEventService] checkWin participants", count)
         if count <= 1 then
                 active = false
                 if count == 1 then
                         reward(last)
                 else
                         WinnerEvent:FireAllClients("")
+                        print("[PickfallEventService] No winner")
                 end
                 task.delay(5, function()
                         resetAll()
@@ -136,7 +139,7 @@ local function checkWin()
 end
 
 local function eliminate(plr)
-
+        print("[PickfallEventService] eliminate", plr and plr.Name)
         participants[plr] = nil
         checkWin()
 end
@@ -152,6 +155,7 @@ RunService.Heartbeat:Connect(function()
                 end
         end
         for _, plr in ipairs(toRemove) do
+                print("[PickfallEventService] Player fell", plr.Name)
                 eliminate(plr)
         end
 end)
@@ -177,7 +181,9 @@ JoinEvent.OnServerEvent:Connect(function(plr)
                 return
         end
         participants[plr] = { startCFrame = hrp.CFrame }
-        print("\tRegistered", plr.Name)
+        local total = 0
+        for _ in pairs(participants) do total += 1 end
+        print("\tRegistered", plr.Name, "total participants", total)
 end)
 
 local function teleport()
@@ -210,19 +216,20 @@ end
 
 local function runRound()
         print("[PickfallEventService] runRound invoked")
-        if not next(participants) then
-                print("\tNo participants")
-                broadcast("idle")
-                registrationOpen = true
-                return
-        end
         registrationOpen = true
-        print("\tCountdown starting with", #participants, "participants")
+        print("\tCountdown starting")
         for t = COUNTDOWN, 1, -1 do
+                print("\tCountdown tick", t)
                 broadcast("countdown", t)
                 task.wait(1)
         end
         registrationOpen = false
+        if not next(participants) then
+                print("\tNo participants after countdown")
+                broadcast("idle")
+                registrationOpen = true
+                return
+        end
         print("\tTeleporting players")
         teleport()
         active = true
@@ -232,9 +239,12 @@ end
 
 local function cycle()
         while true do
+                print("[PickfallEventService] Waiting", ROUND_INTERVAL, "seconds for next round")
                 task.wait(ROUND_INTERVAL)
                 runRound()
-                while active do task.wait(1) end
+                while active do
+                        task.wait(1)
+                end
                 registrationOpen = true
                 broadcast("idle")
         end

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/PickfallController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/PickfallController.lua
@@ -2,7 +2,6 @@
 
 local Players           = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local RunService        = game:GetService("RunService")
 
 local player = Players.LocalPlayer
 
@@ -17,28 +16,33 @@ local PickfallController = {}
 local guiFolder = player:WaitForChild("PlayerGui"):WaitForChild("PickFall")
 
 local gui       = guiFolder:WaitForChild("PickfallGui")
-local joinButton = gui:FindFirstChild("JoinButton") or gui:FindFirstChild("Inscribirse") or gui:FindFirstChildWhichIsA("TextButton")
-local stateLabel = gui:FindFirstChild("StateText") or gui:FindFirstChild("StatusLabel") or gui:FindFirstChildWhichIsA("TextLabel")
-local container = joinButton and joinButton.Parent or gui:FindFirstChildWhichIsA("Frame")
+local container = gui:WaitForChild("Frame")
+local joinButton = container:WaitForChild("JoinButton")
+local countdownLabel = container:WaitForChild("CountDown")
+
+print("[PickfallController] GUI elements", guiFolder, gui, container, joinButton, countdownLabel)
+
+local DEFAULT_JOIN_TEXT = joinButton.Text
 
 local joined = false
-local countdownConn, countdownTime
 
-local function updateCountdown()
-        if not stateLabel then return end
-        local m = math.floor(countdownTime/60)
-        local s = math.floor(countdownTime%60)
-        stateLabel.Text = string.format("Pickfall empieza en %02d:%02d!", m, s)
+local function formatTime(t)
+        local m = math.floor(t/60)
+        local s = math.floor(t%60)
+        return string.format("%02d:%02d", m, s)
 end
 
 function PickfallController.init()
        print("[PickfallController] init")
        if joinButton then
                joinButton.MouseButton1Click:Connect(function()
+                       if joined then return end
                        print("[PickfallController] Join button clicked")
                        JoinEvent:FireServer()
                        joined = true
-                       joinButton.Visible = false
+                       joinButton.Text = "Registrado"
+                       joinButton.AutoButtonColor = false
+                       joinButton.Active = false
                end)
        else
                print("[PickfallController] Join button not found")
@@ -47,56 +51,68 @@ function PickfallController.init()
        StateEvent.OnClientEvent:Connect(function(state, data)
                print("[PickfallController] StateEvent", state, data)
                if state == "idle" then
-                       if countdownConn then
-                               countdownConn:Disconnect()
-                               countdownConn = nil
-                       end
-                       if stateLabel then
-                               stateLabel.Text = "Evento inactivo"
+                       if countdownLabel then
+                               countdownLabel.Text = "00:00"
+                               print("[PickfallController] Countdown reset to 00:00")
                        end
                        joined = false
-                       if joinButton then joinButton.Visible = true end
+                       if joinButton then
+                               joinButton.Text = DEFAULT_JOIN_TEXT
+                               joinButton.AutoButtonColor = true
+                               joinButton.Active = true
+                               joinButton.Visible = true
+                               print("[PickfallController] Join button reset")
+                       end
                elseif state == "countdown" then
-                       countdownTime = tonumber(data) or 0
-                       updateCountdown()
-                       if not countdownConn then
-                               countdownConn = RunService.Heartbeat:Connect(function(dt)
-                                       countdownTime = math.max(0, countdownTime - dt)
-                                       updateCountdown()
-                               end)
+                       local t = tonumber(data) or 0
+                       if countdownLabel then
+                               countdownLabel.Text = formatTime(t)
+                               print("[PickfallController] Countdown updated", countdownLabel.Text)
+                       else
+                               print("[PickfallController] countdownLabel missing during countdown")
                        end
-                       if joinButton then joinButton.Visible = not joined end
+                       if joinButton then
+                               joinButton.Visible = true
+                       else
+                               print("[PickfallController] joinButton missing during countdown")
+                       end
                elseif state == "running" then
-                       if countdownConn then
-                               countdownConn:Disconnect()
-                               countdownConn = nil
+                       if countdownLabel then
+                               countdownLabel.Text = "Evento en progreso"
+                               print("[PickfallController] Round running")
                        end
-                       if stateLabel then
-                               stateLabel.Text = "Evento en progreso"
+                       if joinButton then
+                               joinButton.Visible = false
+                               print("[PickfallController] Join button hidden")
                        end
-                       if joinButton then joinButton.Visible = false end
+               else
+                       print("[PickfallController] Unknown state", state)
                end
                if container then
                        container.Visible = state ~= "running"
+                       print("[PickfallController] Container visibility", container.Visible)
+               else
+                       print("[PickfallController] container missing")
                end
        end)
 
        WinnerEvent.OnClientEvent:Connect(function(name)
                print("[PickfallController] WinnerEvent", name)
-               if countdownConn then
-                       countdownConn:Disconnect()
-                       countdownConn = nil
-               end
-               if stateLabel then
+               if countdownLabel then
                        if name and name ~= "" then
-                               stateLabel.Text = name .. " ganó!"
+                               countdownLabel.Text = name .. " ganó!"
                        else
-                               stateLabel.Text = "Sin ganador"
+                               countdownLabel.Text = "Sin ganador"
                        end
+                       print("[PickfallController] Winner label", countdownLabel.Text)
                end
                joined = false
                if joinButton then
+                       joinButton.Text = DEFAULT_JOIN_TEXT
+                       joinButton.AutoButtonColor = true
+                       joinButton.Active = true
                        joinButton.Visible = true
+                       print("[PickfallController] Join button restored after winner")
                end
                if container then
                        container.Visible = true


### PR DESCRIPTION
## Summary
- wire Pickfall controller to Frame-based JoinButton and CountDown label
- let Pickfall round countdown run regardless of participants, aborting if none join
- update Pickfall controller to display countdown using server-sent time
- add verbose debug logs to controller and server service for troubleshooting

## Testing
- `rojo sourcemap default.project.json --output sourcemap.json`


------
https://chatgpt.com/codex/tasks/task_e_68bb82f82e48832ead470541c5d1aa7b