### PR TITLE
Respawn players at their plot and refresh mining GUI after death

### DIFF
--- a/src/ServerScriptService/ServerModules/Plot/PlotManager.lua
+++ b/src/ServerScriptService/ServerModules/Plot/PlotManager.lua
@@ -66,9 +66,9 @@ local function assignPlot(player)
 end
 
 local function removePlot(player)
-	local plotNameValue = player:FindFirstChild("PlotName")
-	local plotName = plotNameValue and plotNameValue.Value or ""
-	if plotName ~= "" and PlotManager.plotsData[plotName] then
+        local plotNameValue = player:FindFirstChild("PlotName")
+        local plotName = plotNameValue and plotNameValue.Value or ""
+        if plotName ~= "" and PlotManager.plotsData[plotName] then
 		
 		for node in pairs(PlotManager.plotsData[plotName].rocks) do
 			if node and node.Parent then node:Destroy() end
@@ -83,19 +83,35 @@ local function removePlot(player)
 		PlotManager.plotsData[plotName]._lastMaxCrystals = nil
 		print("La parcela " .. plotName .. " ha sido liberada.")
 	end
-	if plotNameValue then plotNameValue.Value = "" end
+        if plotNameValue then plotNameValue.Value = "" end
+end
+
+local function teleportPlayerToOwnPlot(player)
+        local plotNameValue = player:FindFirstChild("PlotName")
+        local plotName = plotNameValue and plotNameValue.Value or ""
+        local data = (plotName ~= "" and PlotManager.plotsData[plotName]) or nil
+        if data then
+                teleportToPlot(player, data.model)
+        end
+end
+
+local function onPlayerAdded(player)
+        assignPlot(player)
+        player.CharacterAdded:Connect(function()
+                teleportPlayerToOwnPlot(player)
+        end)
 end
 
 function PlotManager:init()
-	Players.PlayerAdded:Connect(assignPlot)
-	Players.PlayerRemoving:Connect(removePlot)
+        Players.PlayerAdded:Connect(onPlayerAdded)
+        Players.PlayerRemoving:Connect(removePlot)
 
-	
-	for _, p in ipairs(Players:GetPlayers()) do
-		task.defer(assignPlot, p)
-	end
 
-	print("[PlotManager] Eventos de jugador conectados.")
+        for _, p in ipairs(Players:GetPlayers()) do
+                task.defer(onPlayerAdded, p)
+        end
+
+        print("[PlotManager] Eventos de jugador conectados.")
 end
 function PlotManager:getPlotName(player)
 	local v = player:FindFirstChild("PlotName")

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
@@ -134,15 +134,39 @@ local MiningGUI    = GUIFolder:WaitForChild("MiningGUI")
 local holderFrame  = MiningGUI:WaitForChild("HolderFrame")
 MiningGUI.Enabled  = false
 
+local function refreshGuiRefs()
+    playerGui = player:FindFirstChild("PlayerGui")
+    if not playerGui then return false end
+    GUIFolder = playerGui:FindFirstChild("PickFall")
+    if not GUIFolder then return false end
+    MiningGUI = GUIFolder:FindFirstChild("MiningGUI")
+    if not MiningGUI then return false end
+    holderFrame = MiningGUI:FindFirstChild("HolderFrame")
+    return holderFrame ~= nil
+end
+
+player.CharacterAdded:Connect(function()
+    task.defer(refreshGuiRefs)
+end)
+
 local function updateMiningGUI(model)
     if not model then return end
+    if not holderFrame or not holderFrame.Parent then
+        if not refreshGuiRefs() then return end
+    end
+
+    local nameLabel = holderFrame:FindFirstChild("NameLabel")
+    local healthLabel = holderFrame:FindFirstChild("HealthLabel")
+    local barFrame = holderFrame:FindFirstChild("BarFrame")
+    if not (nameLabel and healthLabel and barFrame) then return end
+
     MiningGUI.Enabled = true
-    holderFrame.NameLabel.Text = model.Name
+    nameLabel.Text = model.Name
     local h  = tonumber(model:GetAttribute("Health")) or 0
     local mh = tonumber(model:GetAttribute("MaxHealth")) or math.max(1, h)
     if h < 0 then h = 0 end
-    holderFrame.HealthLabel.Text = tostring(h) .. " / " .. tostring(mh)
-    holderFrame.BarFrame.Size = UDim2.fromScale(mh > 0 and (h / mh) or 0, 1)
+    healthLabel.Text = tostring(h) .. " / " .. tostring(mh)
+    barFrame.Size = UDim2.fromScale(mh > 0 and (h / mh) or 0, 1)
 end
 
 local function setCrystalProgress(model, ratio)


### PR DESCRIPTION
## Summary
- Teleport players back to their claimed plot whenever their character respawns
- Refresh MiningGUI references and safely update labels, preventing errors after death

## Testing
- `cargo install rojo --version 7.5.1` *(fails: aborted due to long compilation)*
- `selene --version` *(fails: command not found)*
- `luacheck --version` *(fails: command not found)*
- `luau --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e82d648832e8bcaf553a1e0fcb9