### PR TITLE
Expand Pickfall layers and spacing

### DIFF
--- a/src/ServerScriptService/PickFall/HexGenerator.server.lua
+++ b/src/ServerScriptService/PickFall/HexGenerator.server.lua
@@ -1,7 +1,7 @@
 local CFG = {
     layers = 5, -- number of vertical layers
-    layerStep = -20, -- vertical offset between layers
-    radius = 5, -- axial radius of the honeycomb (in tiles)
+    layerStep = -25, -- vertical offset between layers
+    radius = 7, -- axial radius of the honeycomb (in tiles)
     topOffsetY = 0, -- offset from arena base to top layer
     tileYaw = 30, -- rotation of each tile in degrees
     spacingXY = 1.0, -- multiplier for horizontal offsets


### PR DESCRIPTION
## Summary
- increase Pickfall layer radius for larger arenas
- expand vertical layer spacing for clearer separation

## Testing
- `rojo build default.project.json -o build.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_68bb93416f44832e9d108b211adb7596