### PR TITLE
Respect existing ore attributes

### DIFF
--- a/src/ServerScriptService/PickFall/HexGenerator.server.lua
+++ b/src/ServerScriptService/PickFall/HexGenerator.server.lua
@@ -227,13 +227,26 @@ for layer = 1, CFG.layers do
             local cf = CFrame.new(basePos.X + relX, y, basePos.Z + relZ) * CFrame.Angles(0, math.rad(CFG.tileYaw or 0), 0)
 
             pivotTo(clone, cf)
-            clone:SetAttribute("NodeType", oreName)
-            local maxHealth = (oreName == "Stone") and 1 or 20
-            clone:SetAttribute("MaxHealth", maxHealth)
-            clone:SetAttribute("Health", maxHealth)
-            clone:SetAttribute("IsMinable", true)
-            clone:SetAttribute("Reward", 0)
-            clone:SetAttribute("RequiresPickaxe", true)
+            if clone:GetAttribute("NodeType") == nil then
+                clone:SetAttribute("NodeType", oreName)
+            end
+            local maxHealth = clone:GetAttribute("MaxHealth")
+            if maxHealth == nil then
+                maxHealth = (oreName == "Stone") and 1 or 20
+                clone:SetAttribute("MaxHealth", maxHealth)
+            end
+            if clone:GetAttribute("Health") == nil then
+                clone:SetAttribute("Health", maxHealth)
+            end
+            if clone:GetAttribute("IsMinable") == nil then
+                clone:SetAttribute("IsMinable", true)
+            end
+            if clone:GetAttribute("Reward") == nil then
+                clone:SetAttribute("Reward", 0)
+            end
+            if clone:GetAttribute("RequiresPickaxe") == nil then
+                clone:SetAttribute("RequiresPickaxe", true)
+            end
 
             clone.Name = string.format("%s_q%d_r%d", oreName, q, r)
 

--- a/src/ServerScriptService/ServerModules/Plot/NodeSpawner.lua
+++ b/src/ServerScriptService/ServerModules/Plot/NodeSpawner.lua
@@ -157,17 +157,33 @@ local function spawnNode(plotData, nodeType)
         node.Parent = ensureNodesContainer(plotData.model)
 
         
-        if nodeType == "CommonStone" then
-                node:SetAttribute("MaxHealth", 1)
-                node:SetAttribute("Reward", 1)
-        else
-                node:SetAttribute("MaxHealth", 20)
-                node:SetAttribute("Reward", 5)
-        end
-        node:SetAttribute("Health", node:GetAttribute("MaxHealth"))
-        node:SetAttribute("IsMinable", true)
+       if node:GetAttribute("MaxHealth") == nil then
+               if nodeType == "CommonStone" then
+                       node:SetAttribute("MaxHealth", 1)
+               else
+                       node:SetAttribute("MaxHealth", 20)
+               end
+       end
 
-        node:SetAttribute("NodeType", nodeType)
+       if node:GetAttribute("Reward") == nil then
+               if nodeType == "CommonStone" then
+                       node:SetAttribute("Reward", 1)
+               else
+                       node:SetAttribute("Reward", 5)
+               end
+       end
+
+       if node:GetAttribute("Health") == nil then
+               node:SetAttribute("Health", node:GetAttribute("MaxHealth"))
+       end
+
+       if node:GetAttribute("IsMinable") == nil then
+               node:SetAttribute("IsMinable", true)
+       end
+
+       if node:GetAttribute("NodeType") == nil then
+               node:SetAttribute("NodeType", nodeType)
+       end
 
         
         if not node.PrimaryPart then

--- a/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
+++ b/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
@@ -39,16 +39,31 @@ local function setupOreBlocks()
   print("[PickfallEventService] Preparing ore blocks")
   for _, ore in ipairs(oreFolder:GetChildren()) do
     local nodeType = ore:GetAttribute("NodeType") or ore.Name
-    ore:SetAttribute("NodeType", nodeType)
-    local mh = ore:GetAttribute("MaxHealth")
-    if not mh then
-      mh = (ore.Name == "CommonStone") and 1 or 20
+    if ore:GetAttribute("NodeType") == nil then
+      ore:SetAttribute("NodeType", nodeType)
     end
-    ore:SetAttribute("MaxHealth", mh)
-    ore:SetAttribute("Health", ore:GetAttribute("Health") or mh)
-    ore:SetAttribute("IsMinable", true)
-    ore:SetAttribute("Reward", 0)
-    ore:SetAttribute("RequiresPickaxe", true)
+
+    local mh = ore:GetAttribute("MaxHealth")
+    if mh == nil then
+      mh = (ore.Name == "CommonStone") and 1 or 20
+      ore:SetAttribute("MaxHealth", mh)
+    end
+
+    if ore:GetAttribute("Health") == nil then
+      ore:SetAttribute("Health", mh)
+    end
+
+    if ore:GetAttribute("IsMinable") == nil then
+      ore:SetAttribute("IsMinable", true)
+    end
+
+    if ore:GetAttribute("Reward") == nil then
+      ore:SetAttribute("Reward", 0)
+    end
+
+    if ore:GetAttribute("RequiresPickaxe") == nil then
+      ore:SetAttribute("RequiresPickaxe", true)
+    end
 
     if ore:IsA("Model") then
       for _, part in ipairs(ore:GetDescendants()) do


### PR DESCRIPTION
## Summary
- Prevent NodeSpawner from overwriting pre-defined ore attributes
- Preserve configured ore properties in PickfallEventService setup
- Avoid attribute clobbering when generating PickFall hex arena

## Testing
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9a06e7a0832eb12cd4b4ea7589b4