### PR TITLE
Use attributes for mineral nodes instead of tags

### DIFF
--- a/src/ServerScriptService/ServerModules/Plot/NodeSpawner.lua
+++ b/src/ServerScriptService/ServerModules/Plot/NodeSpawner.lua
@@ -1,7 +1,6 @@
 
 
 local ServerStorage     = game:GetService("ServerStorage")
-local CollectionService = game:GetService("CollectionService")
 local Players           = game:GetService("Players")
 local RunService        = game:GetService("RunService")
 
@@ -147,16 +146,15 @@ end
 local function spawnNode(plotData, nodeType)
 	if not (plotData and plotData.model) then return false end
 
-	local zonePart, usedZone = findZonePart(plotData.model, nodeType)
-	if not zonePart then return false end
+        local zonePart = findZonePart(plotData.model, nodeType)
+        if not zonePart then return false end
 
-	local tpl = findTemplate(nodeType)
-	if not tpl then return false end
+        local tpl = findTemplate(nodeType)
+        if not tpl then return false end
 
         local node = tpl:Clone()
-        node.Parent = ensureNodesContainer(plotData.model)
 
-        
+
        if node:GetAttribute("MaxHealth") == nil then
                if nodeType == "CommonStone" then
                        node:SetAttribute("MaxHealth", 1)
@@ -185,7 +183,6 @@ local function spawnNode(plotData, nodeType)
                node:SetAttribute("NodeType", nodeType)
        end
 
-        
         if not node.PrimaryPart then
                 local any = anyBasePart(node)
                 if any then node.PrimaryPart = any end
@@ -193,12 +190,12 @@ local function spawnNode(plotData, nodeType)
 
         placeOnTop(node, zonePart)
 
-        
         if nodeType == "Crystal" then
                 ensureCrystalGui(node)
         end
 
-        
+        node.Parent = ensureNodesContainer(plotData.model)
+
         if nodeType == "CommonStone" then
                 plotData.rocks[node] = true
         else

--- a/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
+++ b/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
@@ -4,7 +4,6 @@ local Players           = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService        = game:GetService("RunService")
 local Workspace         = game:GetService("Workspace")
-local CollectionService = game:GetService("CollectionService")
 
 local Remotes        = ReplicatedStorage:WaitForChild("Remotes")
 local PickfallFolder = Remotes:WaitForChild("PickFall")

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/InputController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/InputController.lua
@@ -2,7 +2,6 @@
 
 local Players            = game:GetService("Players")
 local UserInputService   = game:GetService("UserInputService")
-local CollectionService  = game:GetService("CollectionService")
 local ReplicatedStorage  = game:GetService("ReplicatedStorage")
 local Workspace          = game:GetService("Workspace")
 
@@ -37,23 +36,10 @@ local function isStoneModel(model: Instance?): boolean
 
         local nodeType = model:GetAttribute("NodeType")
         if nodeType then
-                nodeType = string.lower(tostring(nodeType))
-                if nodeType:find("stone", 1, true) then return true end
-                if nodeType == "crystal" then return false end
+                return string.lower(tostring(nodeType)) ~= "crystal"
         end
         if model:GetAttribute("IsMinable") then
                 return true
-        end
-        if CollectionService:HasTag(model, "Stone") then return true end
-        if model:IsA("Model") then
-                if model.PrimaryPart and CollectionService:HasTag(model.PrimaryPart, "Stone") then return true end
-                local hit = model:FindFirstChild("Hitbox")
-                if hit and hit:IsA("BasePart") and CollectionService:HasTag(hit, "Stone") then return true end
-                for _, d in ipairs(model:GetDescendants()) do
-                        if d:IsA("BasePart") and CollectionService:HasTag(d, "Stone") then
-                                return true
-                        end
-                end
         end
         return false
 

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
@@ -3,7 +3,6 @@
 local Players            = game:GetService("Players")
 local RunService         = game:GetService("RunService")
 local UserInputService   = game:GetService("UserInputService")
-local CollectionService  = game:GetService("CollectionService")
 local ReplicatedStorage  = game:GetService("ReplicatedStorage")
 local Workspace          = game:GetService("Workspace")
 
@@ -36,19 +35,6 @@ local function distOK(part)
     return (root and part) and ((root.Position - part.Position).Magnitude <= MAX_DISTANCE) or false
 end
 
-local function hasTagDeep(inst, tag)
-    if CollectionService:HasTag(inst, tag) then return true end
-    if inst:IsA("Model") then
-        if inst.PrimaryPart and CollectionService:HasTag(inst.PrimaryPart, tag) then return true end
-        for _, d in ipairs(inst:GetDescendants()) do
-            if d:IsA("BasePart") and CollectionService:HasTag(d, tag) then
-                return true
-            end
-        end
-    end
-    return false
-end
-
 local function focusPart(inst)
     if not inst then return nil end
     if inst:IsA("BasePart") then return inst end
@@ -70,8 +56,6 @@ local function nodeInfoFrom(inst)
     if inst:GetAttribute("IsMinable") then
         return "Stone", focusPart(inst)
     end
-    if hasTagDeep(inst, "Crystal") then return "Crystal", focusPart(inst) end
-    if hasTagDeep(inst, "Stone") then return "Stone", focusPart(inst) end
     return nil
 end
 
@@ -97,7 +81,7 @@ local function hasEquippedPickaxeClient()
     for _, inst in ipairs(ch:GetChildren()) do
         if inst:IsA("Tool") then
             local lname = inst.Name:lower()
-            if lname:find("pick") or lname:find("pico") or CollectionService:HasTag(inst, "Pickaxe") then
+            if lname:find("pick") or lname:find("pico") or inst:GetAttribute("Pickaxe") then
 
                 return true
             end


### PR DESCRIPTION
## Summary
- register and detect nodes via attributes instead of CollectionService tags
- spawn minerals with attributes set before parenting
- mine logic and client controllers rely on NodeType/IsMinable and Pickaxe attributes

## Testing
- `./rojo_bin/rojo sourcemap default.project.json >/tmp/sourcemap.json`


------
https://chatgpt.com/codex/tasks/task_e_68bb9b1c81ac832e92a96db9f2ff2e01