### PR TITLE
Add weighted ore spawning and updated sounds

### DIFF
--- a/src/ReplicatedStorage/Sounds.rbxmx
+++ b/src/ReplicatedStorage/Sounds.rbxmx
@@ -61,15 +61,15 @@
 				<float name="Volume">0.5</float>
 			</Properties>
 		</Item>
-		<Item class="Sound" referent="RBXC9DF56DA10CC4AD2BDBA7FE8B0D8A7F0">
-			<Properties>
+                <Item class="Sound" referent="RBXC9DF56DA10CC4AD2BDBA7FE8B0D8A7F0">
+                        <Properties>
 				<BinaryString name="AttributesSerialize"></BinaryString>
 				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="DefinesCapabilities">false</bool>
 				<bool name="IsMutedForCapture">false</bool>
 				<NumberRange name="LoopRegion">0 60000 </NumberRange>
 				<bool name="Looped">false</bool>
-				<string name="Name">BreakSound</string>
+                                <string name="Name">StoneSound</string>
 				<bool name="PlayOnRemove">false</bool>
 				<NumberRange name="PlaybackRegion">0 60000 </NumberRange>
 				<bool name="PlaybackRegionsEnabled">false</bool>
@@ -79,13 +79,38 @@
 				<float name="RollOffMinDistance">10</float>
 				<token name="RollOffMode">3</token>
 				<Ref name="SoundGroup">null</Ref>
-				<Content name="SoundId"><url>rbxassetid://7158347304</url></Content>
-				<int64 name="SourceAssetId">-1</int64>
-				<BinaryString name="Tags"></BinaryString>
-				<double name="TimePosition">0</double>
-				<float name="Volume">0.5</float>
-			</Properties>
-		</Item>
+                                <Content name="SoundId"><url>rbxassetid://7158347304</url></Content>
+                                <int64 name="SourceAssetId">-1</int64>
+                                <BinaryString name="Tags"></BinaryString>
+                                <double name="TimePosition">0</double>
+                                <float name="Volume">0.5</float>
+                        </Properties>
+                </Item>
+                <Item class="Sound" referent="RBXGOLDSOUNDREF00000000000000000000">
+                        <Properties>
+                                <BinaryString name="AttributesSerialize"></BinaryString>
+                                <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+                                <bool name="DefinesCapabilities">false</bool>
+                                <bool name="IsMutedForCapture">false</bool>
+                                <NumberRange name="LoopRegion">0 60000 </NumberRange>
+                                <bool name="Looped">false</bool>
+                                <string name="Name">GoldSound</string>
+                                <bool name="PlayOnRemove">false</bool>
+                                <NumberRange name="PlaybackRegion">0 60000 </NumberRange>
+                                <bool name="PlaybackRegionsEnabled">false</bool>
+                                <float name="PlaybackSpeed">1</float>
+                                <bool name="Playing">false</bool>
+                                <float name="RollOffMaxDistance">10000</float>
+                                <float name="RollOffMinDistance">10</float>
+                                <token name="RollOffMode">3</token>
+                                <Ref name="SoundGroup">null</Ref>
+                                <Content name="SoundId"><url>rbxassetid://0</url></Content>
+                                <int64 name="SourceAssetId">-1</int64>
+                                <BinaryString name="Tags"></BinaryString>
+                                <double name="TimePosition">0</double>
+                                <float name="Volume">0.5</float>
+                        </Properties>
+                </Item>
 		<Item class="Sound" referent="RBXE9E80B0A3BCF47D39F12804735242E72">
 			<Properties>
 				<BinaryString name="AttributesSerialize"></BinaryString>

--- a/src/ServerScriptService/PickFall/HexGenerator.server.lua
+++ b/src/ServerScriptService/PickFall/HexGenerator.server.lua
@@ -12,14 +12,13 @@ local CFG = {
     baseWeights = {
         Stone = 40,
         Coal = 25,
-        Bronze = 15,
-        Gold = 10,
-        Emerald = 6,
+        Emerald = 15,
+        Gold = 8,
         Diamond = 4,
     },
     -- Optional per-layer overrides: [layer] = {OreName = weight, ...}
     layerOverrides = {
-        [1] = { Stone = 50, Coal = 30, Bronze = 10, Gold = 5, Emerald = 3, Diamond = 2 },
+        [1] = { Stone = 50, Coal = 30, Emerald = 10, Gold = 6, Diamond = 4 },
         -- Add more overrides as needed
     },
 }
@@ -50,7 +49,7 @@ local function getTemplates()
     assert(folder, "Ore templates not found in expected locations")
     print("HexGenerator: using template folder", folder:GetFullName())
 
-    local names = { "Stone", "Coal", "Bronze", "Gold", "Emerald", "Diamond" }
+    local names = { "Stone", "Coal", "Emerald", "Gold", "Diamond" }
     local templates = {}
     for _, name in ipairs(names) do
         local inst = folder:FindFirstChild(name)
@@ -104,8 +103,8 @@ local function applyRadialBias(weights, dx, dz, size)
     w.Stone = (w.Stone or 0) * (1 + t * 0.5)
     w.Coal = (w.Coal or 0) * (1 + t * 0.3)
     local center = 1 - t
+    w.Emerald = (w.Emerald or 0) * (1 + center * 0.3)
     w.Gold = (w.Gold or 0) * (1 + center * 0.4)
-    w.Emerald = (w.Emerald or 0) * (1 + center * 0.4)
     w.Diamond = (w.Diamond or 0) * (1 + center * 0.6)
     return w
 end

--- a/src/ServerScriptService/Scripts/MiningServer.server.lua
+++ b/src/ServerScriptService/Scripts/MiningServer.server.lua
@@ -116,7 +116,14 @@ SubtractHealthRE.OnServerEvent:Connect(function(player, object, healthSubtractio
     if newHealth <= 0 then
         local pos = objPos(object) or Vector3.new()
         local nodeType = object:GetAttribute("NodeType") or "stone"
-        local soundName = nodeType == "Crystal" and "CrystalSound" or "BreakSound"
+        local soundName
+        if nodeType == "Crystal" then
+            soundName = "CrystalSound"
+        elseif nodeType == "Gold" then
+            soundName = "GoldSound"
+        else
+            soundName = "StoneSound"
+        end
         SoundManager:playSound(soundName, pos)
 
         local reward = tonumber(object:GetAttribute("Reward")) or 0

--- a/src/ServerScriptService/ServerModules/SoundManager.lua
+++ b/src/ServerScriptService/ServerModules/SoundManager.lua
@@ -14,7 +14,8 @@ local function findSoundTemplate(name: string): Sound?
 end
 
 SoundManager.soundTemplates = {
-        BreakSound      = findSoundTemplate("BreakSound"),
+        StoneSound      = findSoundTemplate("StoneSound") or findSoundTemplate("BreakSound"),
+        GoldSound       = findSoundTemplate("GoldSound") or findSoundTemplate("StoneSound") or findSoundTemplate("BreakSound"),
         CrystalSound    = findSoundTemplate("CrystalSound"),
         ProgressCrystal = findSoundTemplate("ProgressCrystal"),
         ConversionSound = findSoundTemplate("ConversionSound"),

--- a/src/ServerScriptService/Services/MiningService.lua
+++ b/src/ServerScriptService/Services/MiningService.lua
@@ -167,7 +167,7 @@ local function mineStone(player, model: Instance)
                 DataService.addResource(player, "stones", reward * buffMultiplier(player))
 
                 EventBus.sendToClient(player, Topics.MiningFeedback, {
-                        kind = "stone",
+                        kind = nodeType or "stone",
                         position = focus.Position,
                 })
                 

--- a/src/StarterPlayer/StarterPlayerScripts/ClientModules/SoundManager.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientModules/SoundManager.lua
@@ -14,7 +14,8 @@ local function findSoundTemplate(name)
 end
 
 SoundManager.soundTemplates = {
-        BreakSound      = findSoundTemplate("BreakSound"),
+        StoneSound      = findSoundTemplate("StoneSound") or findSoundTemplate("BreakSound"),
+        GoldSound       = findSoundTemplate("GoldSound") or findSoundTemplate("StoneSound") or findSoundTemplate("BreakSound"),
         CrystalSound    = findSoundTemplate("CrystalSound"),
         ProgressCrystal = findSoundTemplate("ProgressCrystal"),
         ConversionSound = findSoundTemplate("ConversionSound"),

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/MiningController.lua
@@ -248,7 +248,8 @@ EventBus.registerClient(Topics.MiningFeedback, function(payload)
         end
     else
         if ClientSoundManager and pos then
-            ClientSoundManager:playComboSound("BreakSound", pos)
+            local sound = (kind == "Gold") and "GoldSound" or "StoneSound"
+            ClientSoundManager:playComboSound(sound, pos)
         end
         if pos then
             VisualFX.impactDust(pos)

--- a/src/StarterPlayer/StarterPlayerScripts/Modules/SoundManager.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Modules/SoundManager.lua
@@ -14,7 +14,8 @@ local function findSoundTemplate(name)
 end
 
 SoundManager.soundTemplates = {
-        BreakSound      = findSoundTemplate("BreakSound"),
+        StoneSound      = findSoundTemplate("StoneSound") or findSoundTemplate("BreakSound"),
+        GoldSound       = findSoundTemplate("GoldSound") or findSoundTemplate("StoneSound") or findSoundTemplate("BreakSound"),
         CrystalSound    = findSoundTemplate("CrystalSound"),
         ProgressCrystal = findSoundTemplate("ProgressCrystal"),
         ConversionSound = findSoundTemplate("ConversionSound"),


### PR DESCRIPTION
## Summary
- Spawn Stone, Coal, Emerald, Gold, and Diamond with weighted probabilities
- Play StoneSound or GoldSound based on mined ore
- Replace BreakSound asset with StoneSound and add GoldSound template

## Testing
- `cargo install aftman --locked`
- `rojo build -o build.rbxlx` *(fails: command not found)*
- `aftman install` *(fails: invalid peer certificate)*


------
https://chatgpt.com/codex/tasks/task_e_68bcaba467d8832e8090334c0ce2d9d4