### PR TITLE
Increase stone spawn probability

### DIFF
--- a/src/ServerScriptService/PickFall/HexGenerator.server.lua
+++ b/src/ServerScriptService/PickFall/HexGenerator.server.lua
@@ -10,17 +10,17 @@ local CFG = {
 
     debug = true,
     baseWeights = {
-        Stone = 40,
-        Coal = 25,
-        Bronze = 20,
+        Stone = 70,
+        Coal = 12,
+        Bronze = 8,
 
-        Emerald = 15,
-        Gold = 8,
-        Diamond = 4,
+        Emerald = 5,
+        Gold = 3,
+        Diamond = 2,
     },
     -- Optional per-layer overrides: [layer] = {OreName = weight, ...}
     layerOverrides = {
-        [1] = { Stone = 50, Coal = 30, Bronze = 20, Emerald = 10, Gold = 6, Diamond = 4 },
+        [1] = { Stone = 80, Coal = 10, Bronze = 5, Emerald = 3, Gold = 1, Diamond = 1 },
 
         -- Add more overrides as needed
     },

--- a/src/ServerScriptService/ServerModules/Plot/NodeSpawner.lua
+++ b/src/ServerScriptService/ServerModules/Plot/NodeSpawner.lua
@@ -8,12 +8,12 @@ local nodeTemplates = ServerStorage:WaitForChild("NodeTemplates")
 
 -- weighted list of ore types ordered from lowest to highest value
 local ORE_WEIGHTS = {
-    Stone   = 50,
-    Coal    = 30,
-    Bronze  = 20,
-    Emerald = 10,
-    Gold    = 6,
-    Diamond = 4,
+    Stone   = 80,
+    Coal    = 10,
+    Bronze  = 5,
+    Emerald = 3,
+    Gold    = 1,
+    Diamond = 1,
 }
 
 -- load reward/max-health info from available ore templates so node stats


### PR DESCRIPTION
## Summary
- Reduce non-stone spawn weights so most nodes are stone
- Adjust PickFall hex generator weights for stone dominance

## Testing
- `cargo install aftman`
- `aftman install` *(failed: invalid peer certificate)*
- `rojo build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf495c914832e9e45cc8ab6a31133