### PR TITLE
refactor: reduce logging noise

### DIFF
--- a/src/ServerScriptService/ServerModules/LeaderstatsScript.lua
+++ b/src/ServerScriptService/ServerModules/LeaderstatsScript.lua
@@ -206,26 +206,29 @@ function LeaderstatsScript:init()
 		task.defer(function() givePickaxeIfOwned(player) end)
 	end)
 
-	Players.PlayerRemoving:Connect(function(player)
-		saveData(player.UserId)
-		cache[player.UserId] = nil
-	end)
+        Players.PlayerRemoving:Connect(function(player)
+                saveData(player.UserId)
+                task.wait()
+                cache[player.UserId] = nil
+        end)
 
 	
 	task.spawn(function()
 		while true do
 			task.wait(60)
-			for _, pl in ipairs(Players:GetPlayers()) do
-				saveData(pl.UserId)
-			end
+                        for _, pl in ipairs(Players:GetPlayers()) do
+                                saveData(pl.UserId)
+                                task.wait()
+                        end
 		end
 	end)
 
 	game:BindToClose(function()
-		for _, pl in ipairs(Players:GetPlayers()) do
-			saveData(pl.UserId)
-		end
-	end)
+                for _, pl in ipairs(Players:GetPlayers()) do
+                        saveData(pl.UserId)
+                        task.wait()
+                end
+        end)
 
 	print("[LeaderstatsScript] DataStore listo (gems, stones, upgrades, tools, automine).")
 end

--- a/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
+++ b/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
@@ -91,7 +91,9 @@ local function resetOreBlocks()
 end
 
 local function broadcast(state, data)
-        print("[PickfallEventService] broadcast", state, data)
+        if state ~= "countdown" then
+                print("[PickfallEventService] broadcast", state, data)
+        end
         currentState, currentData = state, data
         StateEvent:FireAllClients(state, data)
 end
@@ -231,9 +233,7 @@ end
 local function runRound()
         print("[PickfallEventService] runRound invoked")
         registrationOpen = true
-        print("\tCountdown starting")
         for t = COUNTDOWN, 1, -1 do
-                print("\tCountdown tick", t)
                 broadcast("countdown", t)
                 task.wait(1)
         end

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/PickfallController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/PickfallController.lua
@@ -20,8 +20,6 @@ local container = gui:WaitForChild("Frame")
 local joinButton = container:WaitForChild("JoinButton")
 local countdownLabel = container:WaitForChild("CountDown")
 
-print("[PickfallController] GUI elements", guiFolder, gui, container, joinButton, countdownLabel)
-
 local DEFAULT_JOIN_TEXT = joinButton.Text
 
 
@@ -35,11 +33,9 @@ local function formatTime(t)
 end
 
 function PickfallController.init()
-       print("[PickfallController] init")
        if joinButton then
                joinButton.MouseButton1Click:Connect(function()
                        if joined then return end
-                       print("[PickfallController] Join button clicked")
                        JoinEvent:FireServer()
                        joined = true
                        joinButton.Text = "Registrado"
@@ -47,15 +43,13 @@ function PickfallController.init()
                        joinButton.Active = false
                end)
        else
-               print("[PickfallController] Join button not found")
+               warn("[PickfallController] Join button not found")
        end
 
        StateEvent.OnClientEvent:Connect(function(state, data)
-               print("[PickfallController] StateEvent", state, data)
                if state == "idle" then
                        if countdownLabel then
                                countdownLabel.Text = "00:00"
-                               print("[PickfallController] Countdown reset to 00:00")
                        end
                        joined = false
                        if joinButton then
@@ -63,60 +57,44 @@ function PickfallController.init()
                                joinButton.AutoButtonColor = true
                                joinButton.Active = true
                                joinButton.Visible = false
-                               print("[PickfallController] Join button reset")
                        end
                        if container then
                                container.Visible = false
-                               print("[PickfallController] Container hidden")
 
                        end
                elseif state == "countdown" then
                        local t = tonumber(data) or 0
                        if countdownLabel then
                                countdownLabel.Text = formatTime(t)
-                               print("[PickfallController] Countdown updated", countdownLabel.Text)
-                       else
-                               print("[PickfallController] countdownLabel missing during countdown")
                        end
                        if joinButton then
                                joinButton.Visible = true
-                       else
-                               print("[PickfallController] joinButton missing during countdown")
                        end
                        if container then
                                container.Visible = true
-                               print("[PickfallController] Container shown")
 
                        end
                elseif state == "running" then
                        if countdownLabel then
                                countdownLabel.Text = "Evento en progreso"
-                               print("[PickfallController] Round running")
                        end
                        if joinButton then
                                joinButton.Visible = false
-                               print("[PickfallController] Join button hidden")
                        end
                        if container then
                                container.Visible = false
-                               print("[PickfallController] Container hidden")
                        end
-               else
-                       print("[PickfallController] Unknown state", state)
 
                end
        end)
 
        WinnerEvent.OnClientEvent:Connect(function(name)
-               print("[PickfallController] WinnerEvent", name)
-
                if countdownLabel then
                        if name and name ~= "" then
                                countdownLabel.Text = name .. " ganó!"
                        else
                                countdownLabel.Text = "Sin ganador"
                        end
-                       print("[PickfallController] Winner label", countdownLabel.Text)
                end
                joined = false
                if joinButton then
@@ -124,7 +102,6 @@ function PickfallController.init()
                        joinButton.AutoButtonColor = true
                        joinButton.Active = true
                        joinButton.Visible = true
-                       print("[PickfallController] Join button restored after winner")
                end
                if container then
                        container.Visible = true


### PR DESCRIPTION
## Summary
- avoid spammy countdown logs for Pickfall events
- trim PickfallController debug prints
- add waits between periodic data saves to ease DataStore queueing

## Testing
- `rojo --version` *(fails: command not found)*
- `luau --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf7ec3f0c832e82b59020a99a4131