### PR TITLE
Fix pickaxe shop ancestor lookup by attribute

### DIFF
--- a/src/ServerScriptService/Scripts/PickaxeShop.server.lua
+++ b/src/ServerScriptService/Scripts/PickaxeShop.server.lua
@@ -15,6 +15,17 @@ local ID_TO_TOOL = {
     crystal = "PickaxeCrystal",
 }
 
+local function findFirstAncestorWithAttribute(instance, attribute)
+    local parent = instance.Parent
+    while parent do
+        if parent:GetAttribute(attribute) ~= nil then
+            return parent
+        end
+        parent = parent.Parent
+    end
+    return nil
+end
+
 local function equipPickaxe(player, id)
     local toolName = ID_TO_TOOL[id]
     if not toolName then return end
@@ -51,7 +62,7 @@ local function equipPickaxe(player, id)
 end
 
 local function handlePurchase(prompt, player)
-    local stand = prompt:FindFirstAncestorWithAttribute("PickaxeId")
+    local stand = findFirstAncestorWithAttribute(prompt, "PickaxeId")
     if not stand then return end
 
     local id = stand:GetAttribute("PickaxeId")

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickaxeShopController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickaxeShopController.lua
@@ -15,6 +15,17 @@ function PickaxeShopController.init()
 
     local currentPrompt
 
+    local function findFirstAncestorWithAttribute(instance, attribute)
+        local parent = instance.Parent
+        while parent do
+            if parent:GetAttribute(attribute) ~= nil then
+                return parent
+            end
+            parent = parent.Parent
+        end
+        return nil
+    end
+
     local function getPrice(stand, id)
         local price = stand:GetAttribute("Price")
         local def = PickaxeDefs[id]
@@ -24,12 +35,12 @@ function PickaxeShopController.init()
         return price
     end
 
-      local function refresh(prompt)
-          local stand = prompt:FindFirstAncestorWithAttribute("PickaxeId")
-          if not stand then return end
-          local id = stand:GetAttribute("PickaxeId")
-          if not id then return end
-          local def = PickaxeDefs[id]
+    local function refresh(prompt)
+        local stand = findFirstAncestorWithAttribute(prompt, "PickaxeId")
+        if not stand then return end
+        local id = stand:GetAttribute("PickaxeId")
+        if not id then return end
+        local def = PickaxeDefs[id]
 
         if not def then return end
 


### PR DESCRIPTION
## Summary
- replace non-existent `FindFirstAncestorWithAttribute` calls with custom helper that walks parents by attribute in pickaxe shop controller and server scripts

## Testing
- `rojo build -o build.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_68bf8ec82d28832e8ace76edabf072f5