### PR TITLE
Add mode selection to PickFall event

### DIFF
--- a/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
+++ b/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
@@ -32,6 +32,10 @@ local participants = {}
 local registrationOpen = false
 local active = false
 
+local currentMode = 1
+local oreTouchedConnections = {}
+local fallingOres = {}
+
 local currentState, currentData = "idle", nil
 
 local function setupOreBlocks()
@@ -79,15 +83,67 @@ local function setupOreBlocks()
 end
 
 local function resetOreBlocks()
-  
+
   setupOreBlocks()
 
-  
+
   for _, ore in ipairs(oreFolder:GetChildren()) do
     if ore:IsA("Model") then
       NodeService.register(ore)
     end
   end
+end
+
+local function connectOreTouch(ore)
+        local function startTimer()
+                if fallingOres[ore] then
+                        return
+                end
+                fallingOres[ore] = true
+                local delayTime = ore:GetAttribute("MaxHealth") or 1
+                task.spawn(function()
+                        for i = delayTime, 1, -1 do
+                                ore:SetAttribute("Health", i - 1)
+                                task.wait(1)
+                        end
+                        if ore:IsA("Model") then
+                                for _, p in ipairs(ore:GetDescendants()) do
+                                        if p:IsA("BasePart") then
+                                                p.Anchored = false
+                                                p.CanCollide = false
+                                        end
+                                end
+                        elseif ore:IsA("BasePart") then
+                                ore.Anchored = false
+                                ore.CanCollide = false
+                        end
+                        task.delay(5, function()
+                                if ore and ore.Parent then
+                                        ore:Destroy()
+                                end
+                        end)
+                end)
+        end
+
+        local function bind(part)
+                local conn = part.Touched:Connect(function(hit)
+                        local plr = Players:GetPlayerFromCharacter(hit.Parent)
+                        if plr then
+                                startTimer()
+                        end
+                end)
+                table.insert(oreTouchedConnections, conn)
+        end
+
+        if ore:IsA("Model") then
+                for _, part in ipairs(ore:GetDescendants()) do
+                        if part:IsA("BasePart") then
+                                bind(part)
+                        end
+                end
+        elseif ore:IsA("BasePart") then
+                bind(ore)
+        end
 end
 
 local function broadcast(state, data)
@@ -109,10 +165,16 @@ local function resetAll()
                         end
                 end
         end
-        participants = {}
-        active = false
-        resetOreBlocks()
-        print("[PickfallEventService] resetAll complete")
+participants = {}
+active = false
+for _, conn in ipairs(oreTouchedConnections) do
+conn:Disconnect()
+end
+oreTouchedConnections = {}
+fallingOres = {}
+currentMode = 1
+resetOreBlocks()
+print("[PickfallEventService] resetAll complete")
 
 end
 
@@ -176,28 +238,28 @@ RunService.Heartbeat:Connect(function()
         end
 end)
 
-JoinEvent.OnServerEvent:Connect(function(plr)
-        print("[PickfallEventService] JoinEvent from", plr and plr.Name, "registrationOpen=", registrationOpen)
-        if not registrationOpen then
-                print("\tRegistration closed")
-                return
-        end
-        if participants[plr] then
-                print("\tAlready registered")
-                return
-        end
-        local char = plr.Character
-        if not char then
-                print("\tNo character")
-                return
-        end
-        local hrp = char:FindFirstChild("HumanoidRootPart")
-        if not hrp then
-                print("\tNo HumanoidRootPart")
-                return
-        end
-        participants[plr] = { startCFrame = hrp.CFrame }
-        local total = 0
+JoinEvent.OnServerEvent:Connect(function(plr, mode)
+print("[PickfallEventService] JoinEvent from", plr and plr.Name, "registrationOpen=", registrationOpen)
+if not registrationOpen then
+print("\tRegistration closed")
+return
+end
+if participants[plr] then
+print("\tAlready registered")
+return
+end
+local char = plr.Character
+if not char then
+print("\tNo character")
+return
+end
+local hrp = char:FindFirstChild("HumanoidRootPart")
+if not hrp then
+print("\tNo HumanoidRootPart")
+return
+end
+participants[plr] = { startCFrame = hrp.CFrame, mode = mode or 1 }
+local total = 0
         for _ in pairs(participants) do total += 1 end
         print("\tRegistered", plr.Name, "total participants", total)
 end)
@@ -237,18 +299,37 @@ local function runRound()
                 broadcast("countdown", t)
                 task.wait(1)
         end
-        registrationOpen = false
-        if not next(participants) then
-                print("\tNo participants after countdown")
-                broadcast("idle")
-                registrationOpen = true
-                return
-        end
-        print("\tTeleporting players")
-        teleport()
-        active = true
-        print("\tRound active")
-        broadcast("running")
+registrationOpen = false
+if not next(participants) then
+print("\tNo participants after countdown")
+broadcast("idle")
+registrationOpen = true
+return
+end
+local counts = {}
+for _, info in pairs(participants) do
+local m = info.mode or 1
+counts[m] = (counts[m] or 0) + 1
+end
+currentMode = 1
+local maxCount = 0
+for m, c in pairs(counts) do
+if c > maxCount then
+maxCount = c
+currentMode = m
+end
+end
+print("\tSelected mode", currentMode)
+print("\tTeleporting players")
+teleport()
+if currentMode == 2 then
+for _, ore in ipairs(oreFolder:GetChildren()) do
+connectOreTouch(ore)
+end
+end
+active = true
+print("\tRound active")
+broadcast("running")
 end
 
 local function cycle()

--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/PickfallController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/PickfallController.lua
@@ -1,5 +1,3 @@
-
-
 local Players           = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
@@ -16,9 +14,12 @@ local PickfallController = {}
 local guiFolder = player:WaitForChild("PlayerGui"):WaitForChild("PickFall")
 
 local gui       = guiFolder:WaitForChild("PickfallGui")
-local container = gui:WaitForChild("Frame")
-local joinButton = container:WaitForChild("JoinButton")
-local countdownLabel = container:WaitForChild("CountDown")
+local registerFrame = gui:WaitForChild("Register")
+local joinButton = registerFrame:WaitForChild("JoinButton")
+local countdownLabel = registerFrame:WaitForChild("CountDown")
+local selectMode = gui:WaitForChild("SelectMode")
+local mode1Button = selectMode:WaitForChild("Mode1")
+local mode2Button = selectMode:WaitForChild("Mode2")
 
 local DEFAULT_JOIN_TEXT = joinButton.Text
 
@@ -26,88 +27,107 @@ local DEFAULT_JOIN_TEXT = joinButton.Text
 local joined = false
 
 local function formatTime(t)
-        local m = math.floor(t/60)
-        local s = math.floor(t%60)
-        return string.format("%02d:%02d", m, s)
+local m = math.floor(t / 60)
+local s = math.floor(t % 60)
+return string.format("%02d:%02d", m, s)
 
 end
 
 function PickfallController.init()
-       if joinButton then
-               joinButton.MouseButton1Click:Connect(function()
-                       if joined then return end
-                       JoinEvent:FireServer()
-                       joined = true
-                       joinButton.Text = "Registrado"
-                       joinButton.AutoButtonColor = false
-                       joinButton.Active = false
-               end)
-       else
-               warn("[PickfallController] Join button not found")
-       end
+selectMode.Visible = false
+local function sendJoin(mode)
+if joined then
+return
+end
+JoinEvent:FireServer(mode)
+joined = true
+joinButton.Text = "Registrado"
+joinButton.AutoButtonColor = false
+joinButton.Active = false
+selectMode.Visible = false
+end
 
-       StateEvent.OnClientEvent:Connect(function(state, data)
-               if state == "idle" then
-                       if countdownLabel then
-                               countdownLabel.Text = "00:00"
-                       end
-                       joined = false
-                       if joinButton then
-                               joinButton.Text = DEFAULT_JOIN_TEXT
-                               joinButton.AutoButtonColor = true
-                               joinButton.Active = true
-                               joinButton.Visible = false
-                       end
-                       if container then
-                               container.Visible = false
+if joinButton then
+joinButton.MouseButton1Click:Connect(function()
+if joined then
+return
+end
+selectMode.Visible = true
+end)
+else
+warn("[PickfallController] Join button not found")
+end
 
-                       end
-               elseif state == "countdown" then
-                       local t = tonumber(data) or 0
-                       if countdownLabel then
-                               countdownLabel.Text = formatTime(t)
-                       end
-                       if joinButton then
-                               joinButton.Visible = true
-                       end
-                       if container then
-                               container.Visible = true
+mode1Button.MouseButton1Click:Connect(function()
+sendJoin(1)
+end)
+mode2Button.MouseButton1Click:Connect(function()
+sendJoin(2)
+end)
 
-                       end
-               elseif state == "running" then
-                       if countdownLabel then
-                               countdownLabel.Text = "Evento en progreso"
-                       end
-                       if joinButton then
-                               joinButton.Visible = false
-                       end
-                       if container then
-                               container.Visible = false
-                       end
+StateEvent.OnClientEvent:Connect(function(state, data)
+if state == "idle" then
+if countdownLabel then
+countdownLabel.Text = "00:00"
+end
+joined = false
+selectMode.Visible = false
+if joinButton then
+joinButton.Text = DEFAULT_JOIN_TEXT
+joinButton.AutoButtonColor = true
+joinButton.Active = true
+joinButton.Visible = false
+end
+if registerFrame then
+        registerFrame.Visible = false
+end
+elseif state == "countdown" then
+local t = tonumber(data) or 0
+if countdownLabel then
+countdownLabel.Text = formatTime(t)
+end
+selectMode.Visible = false
+if joinButton then
+joinButton.Visible = true
+end
+if registerFrame then
+        registerFrame.Visible = true
+end
+elseif state == "running" then
+if countdownLabel then
+countdownLabel.Text = "Evento en progreso"
+end
+selectMode.Visible = false
+if joinButton then
+joinButton.Visible = false
+end
+if registerFrame then
+        registerFrame.Visible = false
+end
+end
+end)
 
-               end
-       end)
-
-       WinnerEvent.OnClientEvent:Connect(function(name)
-               if countdownLabel then
-                       if name and name ~= "" then
-                               countdownLabel.Text = name .. " ganó!"
-                       else
-                               countdownLabel.Text = "Sin ganador"
-                       end
-               end
-               joined = false
-               if joinButton then
-                       joinButton.Text = DEFAULT_JOIN_TEXT
-                       joinButton.AutoButtonColor = true
-                       joinButton.Active = true
-                       joinButton.Visible = true
-               end
-               if container then
-                       container.Visible = true
-               end
-       end)
-
+WinnerEvent.OnClientEvent:Connect(function(name)
+if countdownLabel then
+if name and name ~= "" then
+countdownLabel.Text = name .. " ganó!"
+else
+countdownLabel.Text = "Sin ganador"
+end
+end
+joined = false
+selectMode.Visible = false
+if joinButton then
+joinButton.Text = DEFAULT_JOIN_TEXT
+joinButton.AutoButtonColor = true
+joinButton.Active = true
+joinButton.Visible = true
+end
+if registerFrame then
+        registerFrame.Visible = true
+end
+end)
 end
 
 return PickfallController
+


### PR DESCRIPTION
## Summary
- add client mode selection interface for PickFall
- support different modes on server and implement falling platforms mode
- fix GUI path for mode selection

## Testing
- `./rojo/rojo build -o build.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_68c0575e2244832e99aa49838f7c015d