### PR TITLE
Add mode selection to PickFall event

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/PickfallController.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Controllers/PickFall/PickfallController.lua
@@ -1,5 +1,3 @@
-
-
 local Players           = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
@@ -16,9 +14,12 @@ local PickfallController = {}
 local guiFolder = player:WaitForChild("PlayerGui"):WaitForChild("PickFall")
 
 local gui       = guiFolder:WaitForChild("PickfallGui")
-local container = gui:WaitForChild("Frame")
-local joinButton = container:WaitForChild("JoinButton")
-local countdownLabel = container:WaitForChild("CountDown")
+local registerFrame = gui:WaitForChild("Register")
+local joinButton = registerFrame:WaitForChild("JoinButton")
+local countdownLabel = registerFrame:WaitForChild("CountDown")
+local selectMode = gui:WaitForChild("SelectMode")
+local mode1Button = selectMode:WaitForChild("Mode1")
+local mode2Button = selectMode:WaitForChild("Mode2")
 
 local DEFAULT_JOIN_TEXT = joinButton.Text
 
@@ -26,88 +27,112 @@ local DEFAULT_JOIN_TEXT = joinButton.Text
 local joined = false
 
 local function formatTime(t)
-        local m = math.floor(t/60)
-        local s = math.floor(t%60)
-        return string.format("%02d:%02d", m, s)
+local m = math.floor(t / 60)
+local s = math.floor(t % 60)
+return string.format("%02d:%02d", m, s)
 
 end
 
 function PickfallController.init()
-       if joinButton then
-               joinButton.MouseButton1Click:Connect(function()
-                       if joined then return end
-                       JoinEvent:FireServer()
-                       joined = true
-                       joinButton.Text = "Registrado"
-                       joinButton.AutoButtonColor = false
-                       joinButton.Active = false
-               end)
-       else
-               warn("[PickfallController] Join button not found")
-       end
+selectMode.Visible = false
+local function sendJoin(mode)
+if joined then
+return
+end
+JoinEvent:FireServer(mode)
+joined = true
+joinButton.Text = "Registrado"
+joinButton.AutoButtonColor = false
+joinButton.Active = false
+selectMode.Visible = false
+end
 
-       StateEvent.OnClientEvent:Connect(function(state, data)
-               if state == "idle" then
-                       if countdownLabel then
-                               countdownLabel.Text = "00:00"
-                       end
-                       joined = false
-                       if joinButton then
-                               joinButton.Text = DEFAULT_JOIN_TEXT
-                               joinButton.AutoButtonColor = true
-                               joinButton.Active = true
-                               joinButton.Visible = false
-                       end
-                       if container then
-                               container.Visible = false
+if joinButton then
+joinButton.MouseButton1Click:Connect(function()
+if joined then
+return
+end
+joinButton.Active = false
+joinButton.AutoButtonColor = false
+selectMode.Visible = true
+end)
+else
+warn("[PickfallController] Join button not found")
+end
 
-                       end
-               elseif state == "countdown" then
-                       local t = tonumber(data) or 0
-                       if countdownLabel then
-                               countdownLabel.Text = formatTime(t)
-                       end
-                       if joinButton then
-                               joinButton.Visible = true
-                       end
-                       if container then
-                               container.Visible = true
+mode1Button.MouseButton1Click:Connect(function()
+sendJoin(1)
+end)
+mode2Button.MouseButton1Click:Connect(function()
+sendJoin(2)
+end)
 
-                       end
-               elseif state == "running" then
-                       if countdownLabel then
-                               countdownLabel.Text = "Evento en progreso"
-                       end
-                       if joinButton then
-                               joinButton.Visible = false
-                       end
-                       if container then
-                               container.Visible = false
-                       end
+StateEvent.OnClientEvent:Connect(function(state, data)
+if state == "idle" then
+if countdownLabel then
+countdownLabel.Text = "00:00"
+end
+joined = false
+selectMode.Visible = false
+if joinButton then
+joinButton.Text = DEFAULT_JOIN_TEXT
+joinButton.AutoButtonColor = true
+joinButton.Active = true
+joinButton.Visible = false
+end
+if registerFrame then
+        registerFrame.Visible = false
+end
+elseif state == "countdown" then
+ local t = tonumber(data) or 0
+ if countdownLabel then
+ countdownLabel.Text = formatTime(t)
+ end
+ if not selectMode.Visible and not joined then
+ if joinButton then
+ joinButton.Visible = true
+ joinButton.Active = true
+ joinButton.AutoButtonColor = true
+ end
+ if registerFrame then
+        registerFrame.Visible = true
+ end
+ end
+elseif state == "running" then
+if countdownLabel then
+countdownLabel.Text = "Evento en progreso"
+end
+selectMode.Visible = false
+if joinButton then
+joinButton.Visible = false
+end
+if registerFrame then
+        registerFrame.Visible = false
+end
+end
+end)
 
-               end
-       end)
-
-       WinnerEvent.OnClientEvent:Connect(function(name)
-               if countdownLabel then
-                       if name and name ~= "" then
-                               countdownLabel.Text = name .. " ganó!"
-                       else
-                               countdownLabel.Text = "Sin ganador"
-                       end
-               end
-               joined = false
-               if joinButton then
-                       joinButton.Text = DEFAULT_JOIN_TEXT
-                       joinButton.AutoButtonColor = true
-                       joinButton.Active = true
-                       joinButton.Visible = true
-               end
-               if container then
-                       container.Visible = true
-               end
-       end)
-
+WinnerEvent.OnClientEvent:Connect(function(name)
+if countdownLabel then
+if name and name ~= "" then
+countdownLabel.Text = name .. " ganó!"
+else
+countdownLabel.Text = "Sin ganador"
+end
+end
+joined = false
+selectMode.Visible = false
+if joinButton then
+joinButton.Text = DEFAULT_JOIN_TEXT
+joinButton.AutoButtonColor = true
+joinButton.Active = true
+joinButton.Visible = true
+end
+if registerFrame then
+        registerFrame.Visible = true
+end
+end)
 end
 
 return PickfallController
+


### PR DESCRIPTION
## Summary
- keep mode-selection UI open until a mode is chosen
- parse and track numeric modes on the server and prepare falling platforms

## Testing
- `./rojo/rojo build -o build.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_68c0575e2244832e99aa49838f7c015d