### PR TITLE
Highlight touched ores with mineral color in Pickfall mode 2

### DIFF
--- a/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
+++ b/src/ServerScriptService/Services/PickFall/PickfallEventService.lua
@@ -106,11 +106,29 @@ local function connectOreTouch(ore)
                 fallingOres[ore] = true
                 print("[PickfallEventService] ore touched", ore.Name)
 
+                local highlight = Instance.new("Highlight")
+                highlight.DepthMode = Enum.HighlightDepthMode.AlwaysOnTop
+                highlight.Adornee = ore
+
+                local color
+                if ore:IsA("BasePart") then
+                        color = ore.Color
+                else
+                        local part = ore.PrimaryPart or ore:FindFirstChildWhichIsA("BasePart", true)
+                        color = part and part.Color or Color3.new(1, 1, 1)
+                end
+                highlight.FillColor = color
+                highlight.OutlineColor = color
+                highlight.Parent = ore
+
                 local delayTime = ore:GetAttribute("MaxHealth") or 1
                 task.spawn(function()
                         for i = delayTime, 1, -1 do
                                 ore:SetAttribute("Health", i - 1)
                                 task.wait(1)
+                        end
+                        if highlight then
+                                highlight:Destroy()
                         end
                         if ore:IsA("Model") then
                                 for _, p in ipairs(ore:GetDescendants()) do


### PR DESCRIPTION
## Summary
- add highlight effect when ore blocks are touched in Pickfall mode 2
- highlight uses the ore's color and is removed when the block falls

## Testing
- `rojo --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06dd1048c832eb4f28195fc00a44e